### PR TITLE
Clone Composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,5 @@ npm i --save @prefecthq/vue-compositions
 ```
 
 ## Compositions
+- [clone](https://github.com/PrefectHQ/vue-compositions/tree/main/src/clone)
 - [subscribe](https://github.com/PrefectHQ/vue-compositions/tree/main/src/subscribe)

--- a/src/clone/README.md
+++ b/src/clone/README.md
@@ -1,0 +1,22 @@
+# Clone
+The `clone` composition 
+
+## Example
+```typescript
+import { clone } from '@prefecthq/vue-compositions'
+
+const source = reactive({ hello: 'world' })
+const copy = clone(source)
+```
+
+## How it works
+`clone` creates an exact copy of the source passed in. It retains prototypes and classes while breaking object references. It also retains the reactive proxy for an object if one is present. For example a source of `reactive({ user: new User() })` would retain both the reactive proxy as well as the `User` instance. But it would return a completely new instance of both. 
+
+## Known limitations
+Vue.js currently does not provide an `isShallow` method or expose a marker to allow checking if a reactive object is shallow. There's an open github issue for this [3044](https://github.com/vuejs/vue-next/issues/3044).
+
+To account for this `clone` accepts an optional options argument where you can specify that shallow reactive proxies should be used. 
+
+```javascript
+const copy = clone(source, { shallow: true })
+```

--- a/src/clone/clone.ts
+++ b/src/clone/clone.ts
@@ -1,0 +1,44 @@
+import { getCurrentInstance, isReactive, isRef, onUnmounted, reactive, shallowReactive, watch } from "vue";
+
+function cloner<T>(source: T, options: { shallow: boolean } = { shallow: false}): T {
+    if(source === null || typeof source !== 'object') {
+        return source
+    }
+    
+    let temp = new (source as any).constructor()
+    
+    for(let key in source) {
+        temp[key] = cloner(source[key])
+    }
+    
+    if(isReactive(source)) {
+        return options.shallow ? shallowReactive(temp) : reactive(temp)
+    }
+    
+    return temp;
+}
+
+function isUnknownObject(value: unknown): value is object {
+    return typeof value === 'object'
+}
+
+export function clone<T>(source: T, options: { shallow: boolean } = { shallow: false}): T {
+    const copy = cloner(source, options)
+    let unwatch: ReturnType<typeof watch>
+    
+    if(isUnknownObject(source) && (isRef(source) || isReactive(source))) {
+        unwatch = watch(source, () => {
+            Object.assign(copy, cloner(source, options))
+        }, { deep: true })
+    }
+        
+    if(getCurrentInstance()) {
+        onUnmounted(() => {
+            if(unwatch) {
+                unwatch()
+            }
+        })
+    }
+
+    return copy
+}

--- a/src/clone/index.ts
+++ b/src/clone/index.ts
@@ -1,0 +1,1 @@
+export * from './clone'

--- a/tests/clone/clone.spec.ts
+++ b/tests/clone/clone.spec.ts
@@ -1,0 +1,136 @@
+import { clone } from '@/clone'
+import { isReactive, isRef, reactive, ref, shallowReactive } from 'vue'
+import { timeout } from '../utils'
+
+describe('clone', () => {
+
+    it('clones primitive sources', () => {
+        const source = 0
+        const copy = clone(source)
+
+        expect(source === copy).toBe(true)
+    })
+
+    it('clones array sources', () => {
+        const source = [0]
+        const copy = clone(source)
+
+        expect(JSON.stringify(source) === JSON.stringify(copy)).toBe(true)
+    })
+
+    it('clones object sources', () => {
+        const source = { source: 0 }
+        const copy = clone(source)
+
+        expect(JSON.stringify(source) === JSON.stringify(copy)).toBe(true)
+    })
+
+    it('breaks array reference', () => {
+        const source = [0]
+        const copy = clone(source)
+
+        expect(source == copy).toBe(false)
+    })
+
+    it('breaks object reference', () => {
+        const source = { source: 0 }
+        const copy = clone(source)
+
+        expect(source === copy).toBe(false)
+    })
+
+    it('breaks reactive reference', async () => {
+        const child = { hello: 'world' }
+        const source = reactive({ child })
+        const copy = clone(source)
+
+        child.hello = 'bob'
+
+        await timeout()
+
+        expect(source.child === copy.child).toBe(false)
+    })
+
+    it('breaks ref reference', async () => {
+        const child = ref({ hello: 'world'} )
+        const source = reactive({ child })
+        const copy = clone(source)
+
+        child.value.hello = 'bob'
+
+        await timeout()
+
+        expect(source.child === copy.child).toBe(false)
+    })
+
+    it('retains prototype', () => {
+        class MyClass {}
+
+        const source = new MyClass()
+        const copy = clone(source)
+
+        expect(copy instanceof MyClass).toBe(true)
+    })
+
+    it('retains prototype recursively', () => {
+        class MySubClass {}
+        class MyParentClass {
+            public myProperty = new MySubClass()
+        }
+
+        const source = new MyParentClass()
+        const copy = clone(source)
+
+        expect(copy.myProperty instanceof MySubClass).toBe(true)
+    })
+
+    it('retains reactive proxy', () => {
+        const source = reactive({ hello: 'world '})
+        const copy = clone(source)
+
+        expect(isReactive(copy)).toBe(true)
+    })
+
+    it('does not retain shallowReactive proxy by default', () => {
+        const source = shallowReactive({ hello: ref('world') })
+        const copy = clone(source)
+
+        expect(isRef(copy.hello)).toBe(false)
+    })
+
+    it('does not retain shallowReactive proxy when shallow options is used', () => {
+        const source = shallowReactive({ hello: ref('world') })
+        const copy = clone(source, { shallow: true })
+
+        expect(isRef(copy.hello)).toBe(true)
+    })
+
+    it('retains ref', () => {
+        const source = ref(0)
+        const copy = clone(source)
+
+        expect(isRef(copy)).toBe(true)
+    })
+
+    it('updates response when source is a ref', async () => {
+        const source = ref(0)
+        const copy = clone(source)
+
+        source.value = 1
+
+        await timeout()
+
+        expect(copy.value).toBe(1)
+    })
+
+    it('updates response when source is reactive', async () => {
+        const source = reactive({ number: 0 })
+        const copy = clone(source)
+
+        source.number = 1
+
+        await timeout()
+
+        expect(copy.number).toBe(1)
+    })
+})


### PR DESCRIPTION
This composition was originally created to use with the `subscribe` composition but ended up not being needed. Leaving this PR open until a valid use case is submitted