### PR TITLE
Composition Aliases and Subscription Quality of Life Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ npm i --save @prefecthq/vue-compositions
 ```
 
 ## Compositions
-- [media](https://github.com/PrefectHQ/vue-compositions/tree/main/src/media)
-- [subscribe](https://github.com/PrefectHQ/vue-compositions/tree/main/src/subscribe)
+- [useMedia](https://github.com/PrefectHQ/vue-compositions/tree/main/src/media)
+- [useSubscription](https://github.com/PrefectHQ/vue-compositions/tree/main/src/subscribe)

--- a/src/media/README.md
+++ b/src/media/README.md
@@ -1,12 +1,12 @@
 # Media
-The `media` composition is a reactive wrapper around [window.matchMedia](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia) which can be used to react to changes to the document's [type and media](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#syntax) features. 
+The `useMedia` composition is a reactive wrapper around [window.matchMedia](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia) which can be used to react to changes to the document's [type and media](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#syntax) features. 
 
 ## Example
 ```typescript
-import { media } from '@prefecthq/vue-compositions'
+import { useMedia } from '@prefecthq/vue-compositions'
 
-export const small = media('(min-width: 640px)')
-export const medium = media('(min-width: 1024px)')
+export const small = useMedia('(min-width: 640px)')
+export const medium = useMedia('(min-width: 1024px)')
 ```
 
 ## Arguments

--- a/src/media/media.ts
+++ b/src/media/media.ts
@@ -1,5 +1,7 @@
 import { getCurrentInstance, isRef, onUnmounted, ref, Ref, unref, watch } from 'vue'
-
+/**
+ * @deprecated use useMedia instead
+ */
 export function media(query: Ref<string> | string): Ref<boolean> {
   let mediaQuery = window.matchMedia(unref(query))
   const matches = ref(mediaQuery.matches)

--- a/src/media/media.ts
+++ b/src/media/media.ts
@@ -31,3 +31,5 @@ export function media(query: Ref<string> | string): Ref<boolean> {
 
   return matches
 }
+
+export const useMedia = media

--- a/src/subscribe/README.md
+++ b/src/subscribe/README.md
@@ -1,11 +1,11 @@
 # Subscribe
-The `subscribe` composition manages data sharing across components. Multiple components can subscribe to an `action` (any method or function) and and share the response value. 
+The `useSubscription` composition manages data sharing across components. Multiple components can subscribe to an `action` (any method or function) and and share the response value. 
 
 ## Example
 ```typescript
-import { subscribe } from '@prefecthq/vue-compositions'
+import { useSubscription } from '@prefecthq/vue-compositions'
 
-const subscription = subscribe(action, args, options)
+const subscription = useSubscription(action, args, options)
 ```
 
 ## How it works

--- a/src/subscribe/createActions.ts
+++ b/src/subscribe/createActions.ts
@@ -1,0 +1,14 @@
+type Callable<T> = {
+  [P in keyof T]: T[P] extends (...args: any[]) => any ? P : never
+}[keyof T]
+
+export function createActions<T extends Record<string, any>>(context: T): Pick<T, Callable<T>> {
+  const keys = Object.keys(context).filter(key => typeof context[key] === 'function')
+  const value = {} as Pick<T, Callable<T>>
+
+  return keys.reduce<Pick<T, Callable<T>>>((output, method) => {
+    output[method as Callable<T>] = context[method].bind(context)
+
+    return output
+  }, value)
+}

--- a/src/subscribe/createActions.ts
+++ b/src/subscribe/createActions.ts
@@ -1,6 +1,7 @@
-type Callable<T> = {
-  [P in keyof T]: T[P] extends (...args: any[]) => any ? P : never
-}[keyof T]
+type AnyFunction = (...args: any[]) => any
+type Callable<T> = keyof {
+  [P in keyof T as T[P] extends AnyFunction ? P : never]: T[P]
+}
 
 export function createActions<T extends Record<string, any>>(context: T): Pick<T, Callable<T>> {
   const keys = Object.keys(context).filter(key => typeof context[key] === 'function')

--- a/src/subscribe/index.ts
+++ b/src/subscribe/index.ts
@@ -1,1 +1,2 @@
+export * from './createActions'
 export * from './subscribe'

--- a/src/subscribe/subscribe.ts
+++ b/src/subscribe/subscribe.ts
@@ -49,3 +49,5 @@ export function subscribe<T extends Action>(
 
   return subscription
 }
+
+export const useSubscription = subscribe

--- a/src/subscribe/subscribe.ts
+++ b/src/subscribe/subscribe.ts
@@ -1,7 +1,7 @@
 import { getCurrentInstance, isReactive, isRef, onUnmounted, shallowReactive, unref, watch } from 'vue'
 import Manager from './manager'
 import Subscription from './subscription'
-import { Action, ActionArguments, SubscriptionOptions } from './types'
+import { Action, ActionArguments, SubscribeArguments, SubscriptionOptions } from './types'
 
 const defaultManager = new Manager()
 
@@ -50,4 +50,10 @@ export function subscribe<T extends Action>(
   return subscription
 }
 
-export const useSubscription = subscribe
+export function useSubscription<T extends Action>(...[action, args, options, manager]: SubscribeArguments<T>): Subscription<T> {
+  const argsWithDefault = args ?? ([] as unknown as ActionArguments<T>)
+  const optionsWithDefault = options ?? {}
+  const managerWithDefault = manager ?? defaultManager
+
+  return subscribe(action, argsWithDefault, optionsWithDefault, managerWithDefault)
+}

--- a/src/subscribe/subscribe.ts
+++ b/src/subscribe/subscribe.ts
@@ -5,6 +5,9 @@ import { Action, ActionArguments, SubscribeArguments, SubscriptionOptions } from
 
 const defaultManager = new Manager()
 
+/**
+ * @deprecated use useSubscription instead
+ */
 // I don't think this method makes sense with 3 params
 // eslint-disable-next-line max-params
 export function subscribe<T extends Action>(

--- a/src/subscribe/types.ts
+++ b/src/subscribe/types.ts
@@ -1,13 +1,13 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Ref, UnwrapRef } from 'vue'
+import Manager from './manager'
 
 type ToPossibleRefs<T> = {
   [K in keyof T]: T[K] | Ref<UnwrapRef<T[K]>>
 }
 
-type MaybeRefs<T> = T | Ref<T> | ToPossibleRefs<T> | Ref<ToPossibleRefs<T>>
+type MaybeRefs<T extends any[]> = ToPossibleRefs<T> | Ref<ToPossibleRefs<T>>
 
-// any is necessary in order to infer the action's args and return type
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Action = (...args: any[]) => any
 export type ActionArguments<T extends Action> = MaybeRefs<Parameters<T>>
 export type ActionResponse<T extends Action> = Awaited<ReturnType<T>>
@@ -17,3 +17,10 @@ export type ChannelSignature = `${number}-${string}`
 export type SubscriptionOptions = {
   interval?: number,
 }
+
+type OnlyRequired<T extends any[], U extends any[] = []> = Partial<T> extends T ? U : T extends [infer F, ...infer R] ? OnlyRequired<R, [...U, F]> : U
+type ActionParamsRequired<T extends Action> = OnlyRequired<Parameters<T>>
+
+export type SubscribeArguments<T extends Action> = ActionParamsRequired<T> extends never[]
+  ? [action: T, args?: ActionArguments<T>, options?: SubscriptionOptions, manager?: Manager ]
+  : [action: T, args: ActionArguments<T>, options?: SubscriptionOptions, manager?: Manager ]


### PR DESCRIPTION
# Description
Its a community standard for compositions to follow the `useThing` naming convention. Adding aliases for both `media` and `subscribe` that use this naming convention. `media` and `subscribe` are now deprecated in favor of `useMedia` and `useSubscription`

Included in this PR are a couple quality of life improvements around creating subscriptions. When using `useSubscription` the `args` argument is no longer required when the action has no required arguments. This means it's no longer necessary to pass in an empty array like `useSubscription(myAction, [])`. You can just use `useSubscription(myAction)`

Using `useSubscription` with classes or objects has been inconvenient because of the binding issue with actions. This PR introduces a new utility called `createActions` that helps make using classes with `useSubscription` more convenient.

## Example
Currently this is how we export services
```typescript
class MyService {
  private greeting = 'hello'

  public greet() {
    return this.greeting // this line is the issue. `this` context gets changed when the action is executed in a subscription.
  }
}

export const myService = new MyService()
```
And because of the context issue this is how we're using services with subscriptions

```typescript
import { myService } from '@/services/MyService'
import { useSubscription } from '@prefecthq/vue-compositions'

const subscription = useSubscription(myService.greet.bind(myService))
```
Having to bind the class to the method is annoying. Using the `createActions` utility we can bind the correct context ahead of time. Changing the `mySerivce` export to this
```typescript
import { createActions } from '@prefecthq/vue-compositions'`

class MyService {
  ...
}

export const myService = createActions(new MyService())
```
Means we can skip the binding at implementation
```typescript
import { myService } from '@/services/MyService'
import { useSubscription } from '@prefecthq/vue-compositions'

const subscription = subscribe(myService.greet)
```
