### PR TITLE
Bug: Fix types not working for class instances when using createActions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@prefecthq/vue-compositions",
   "private": false,
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "A collection of reusable vue compositions.",
   "main": "index.ts",
   "scripts": {

--- a/src/subscribe/createActions.ts
+++ b/src/subscribe/createActions.ts
@@ -3,7 +3,9 @@ type Callable<T> = keyof {
   [P in keyof T as T[P] extends AnyFunction ? P : never]: T[P]
 }
 
-export function createActions<T extends Record<string, unknown>>(context: T): Pick<T, Callable<T>> {
+// we do specifically want any here. unknown breaks this for classes
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function createActions<T extends Record<string, any>>(context: T): Pick<T, Callable<T>> {
   const value = {} as Pick<T, Callable<T>>
 
   return Object.keys(context).reduce<Pick<T, Callable<T>>>((output, key) => {


### PR DESCRIPTION
`Record<string, unknown>` made createActions throw a type error if you passed in a class instance. Change it to any correctly errors for simple values while allowing class instances to work. 