### PR TITLE
Bugfix: Ignore non function members like getters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@prefecthq/vue-compositions",
   "private": false,
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "A collection of reusable vue compositions.",
   "main": "index.ts",
   "scripts": {

--- a/src/subscribe/createActions.ts
+++ b/src/subscribe/createActions.ts
@@ -23,7 +23,7 @@ export function createActions<T extends Record<string, any>>(context: T): OnlyCa
   // methods
   while (prototype && prototype !== Object.prototype) {
     Reflect.ownKeys(prototype).forEach(key => {
-      if (typeof key === 'string' && !objectPrototypeKeys.includes(key)) {
+      if (typeof key === 'string' && typeof context[key] === 'function' && !objectPrototypeKeys.includes(key)) {
         // any necessary because Reflect.getPrototypeOf returns object
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         actions[key] = (prototype as any)[key].bind(context)

--- a/tests/subscribe/createActions.spec.ts
+++ b/tests/subscribe/createActions.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/class-literal-property-style */
 /* eslint-disable max-classes-per-file */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { createActions } from '@/subscribe'
@@ -60,7 +61,7 @@ describe('createActions', () => {
     expect(actions.cappa).toBeUndefined()
   })
 
-  it('does return inherited class methods', () => {
+  it('does return inherited class members are functions', () => {
     class Beta {
       public cappa(): string {
         return 'cappa'
@@ -72,6 +73,18 @@ describe('createActions', () => {
     const actions = createActions(new Alpha)
 
     expect(actions.cappa).toBeDefined()
+  })
+
+  it('does not return class members that are not methods', () => {
+    class Alpha {
+      public get alpha(): string {
+        return 'alpha'
+      }
+    }
+
+    const actions = createActions(new Alpha)
+
+    expect(Object.keys(actions).length).toBe(0)
   })
 
   it('does not return inherited object prototype', () => {


### PR DESCRIPTION
# Description
Update the logic that gets instance members to only return members that are functions.