### PR TITLE
BugFix: createActions overridden members

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@prefecthq/vue-compositions",
   "private": false,
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "A collection of reusable vue compositions.",
   "main": "index.ts",
   "scripts": {

--- a/src/subscribe/createActions.ts
+++ b/src/subscribe/createActions.ts
@@ -23,7 +23,7 @@ export function createActions<T extends Record<string, any>>(context: T): OnlyCa
   // methods
   while (prototype && prototype !== Object.prototype) {
     Reflect.ownKeys(prototype).forEach(key => {
-      if (typeof key === 'string' && typeof context[key] === 'function' && !objectPrototypeKeys.includes(key)) {
+      if (typeof key === 'string' && typeof actions[key] === 'undefined' && typeof context[key] === 'function' && !objectPrototypeKeys.includes(key)) {
         // any necessary because Reflect.getPrototypeOf returns object
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         actions[key] = (prototype as any)[key].bind(context)

--- a/tests/subscribe/createActions.spec.ts
+++ b/tests/subscribe/createActions.spec.ts
@@ -87,6 +87,24 @@ describe('createActions', () => {
     expect(Object.keys(actions).length).toBe(0)
   })
 
+  it('does override instance members', () => {
+    class Beta {
+      public cappa(): string {
+        return 'beta'
+      }
+    }
+
+    class Alpha extends Beta {
+      public cappa(): string {
+        return 'alpha'
+      }
+    }
+
+    const actions = createActions(new Alpha)
+
+    expect(actions.cappa()).toEqual('alpha')
+  })
+
   it('does not return inherited object prototype', () => {
     class Alpha {}
 


### PR DESCRIPTION
# Description
`createAction` would return the overridden members rather than the overrides. Checking if the action was already added prevents that from happening. Added test to confirm. 