### PR TITLE
Fix response undefined and vue watch warnings

### DIFF
--- a/src/subscribe/channel.ts
+++ b/src/subscribe/channel.ts
@@ -1,9 +1,11 @@
 /* eslint-disable max-classes-per-file */
+import { ref, Ref } from 'vue'
 import Manager from './manager'
 import Subscription from './subscription'
 import {
   Action,
   ActionArguments,
+  ActionResponse,
   ChannelSignature,
   SubscriptionOptions
 } from './types'
@@ -42,6 +44,7 @@ export default class Channel<T extends Action = Action> {
   private readonly action: T
   private readonly args: ActionArguments<T>
   private readonly subscriptions: Map<number, Subscription<T>> = new Map()
+  private response: ActionResponse<T> | undefined = undefined
   private timer: ReturnType<typeof setInterval> | null = null
   private lastExecution: number = 0
 
@@ -78,14 +81,8 @@ export default class Channel<T extends Action = Action> {
     }
   }
 
-  private set response(response: Awaited<ReturnType<T>>) {
-    for (const subscription of this.subscriptions.values()) {
-      subscription.response.value = response
-    }
-  }
-
   public subscribe(options: SubscriptionOptions): Subscription<T> {
-    const subscription = new Subscription(this, options)
+    const subscription = new Subscription(this, options, this.response)
 
     this.subscriptions.set(subscription.id, subscription)
 
@@ -118,7 +115,7 @@ export default class Channel<T extends Action = Action> {
     this.setInterval()
 
     try {
-      this.response = await this.action(...args)
+      this.setResponse(await this.action(...args))
       this.errored = false
       this.error = null
     } catch (error) {
@@ -131,6 +128,14 @@ export default class Channel<T extends Action = Action> {
 
   public isSubscribed(id: number): boolean {
     return this.subscriptions.has(id)
+  }
+
+  private setResponse(response: Awaited<ReturnType<T>>) {
+    this.response = response
+
+    for (const subscription of this.subscriptions.values()) {
+      subscription.response.value = response
+    }
   }
 
   private setInterval(): void {

--- a/src/subscribe/channel.ts
+++ b/src/subscribe/channel.ts
@@ -1,5 +1,4 @@
 /* eslint-disable max-classes-per-file */
-import { ref, Ref } from 'vue'
 import Manager from './manager'
 import Subscription from './subscription'
 import {

--- a/src/subscribe/subscribe.ts
+++ b/src/subscribe/subscribe.ts
@@ -2,6 +2,7 @@ import { getCurrentInstance, isReactive, isRef, onUnmounted, shallowReactive, un
 import Manager from './manager'
 import Subscription from './subscription'
 import { Action, ActionArguments, SubscribeArguments, SubscriptionOptions } from './types'
+import { watchableArgs } from './utilities'
 
 const defaultManager = new Manager()
 
@@ -25,9 +26,11 @@ export function subscribe<T extends Action>(
     (unref(args) as Parameters<T>).some(isRef) ||
     (unref(args) as Parameters<T>).some(isReactive)
   ) {
+    const argsToWatch = watchableArgs(args)
+
     unwatch = watch(
-      args,
-      (newArgs) => {
+      argsToWatch,
+      () => {
         if (!subscription.isSubscribed()) {
           unwatch!()
           return
@@ -35,7 +38,7 @@ export function subscribe<T extends Action>(
 
         subscription.unsubscribe()
 
-        const newSubscription = manager.subscribe(action, newArgs, options)
+        const newSubscription = manager.subscribe(action, args, options)
 
         newSubscription.response.value ??= subscription.response.value
 

--- a/src/subscribe/subscribe.ts
+++ b/src/subscribe/subscribe.ts
@@ -34,7 +34,12 @@ export function subscribe<T extends Action>(
         }
 
         subscription.unsubscribe()
-        Object.assign(subscription, manager.subscribe(action, newArgs, options))
+
+        const newSubscription = manager.subscribe(action, newArgs, options)
+
+        newSubscription.response.value ??= subscription.response.value
+
+        Object.assign(subscription, newSubscription)
       },
       { deep: true },
     )

--- a/src/subscribe/subscription.ts
+++ b/src/subscribe/subscription.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-classes-per-file */
 import { ref, Ref, watch } from 'vue'
 import Channel from './channel'
-import { Action, SubscriptionOptions } from './types'
+import { Action, ActionResponse, SubscriptionOptions } from './types'
 
 class SubscriptionIdManager {
   private static id: number = 0
@@ -15,16 +15,17 @@ export default class Subscription<T extends Action> {
   public readonly id: number
   public readonly options: SubscriptionOptions
   public loading: Ref<boolean> = ref(false)
-  public response: Ref<Awaited<ReturnType<T>> | undefined> = ref(undefined)
+  public response: Ref<ActionResponse<T>| undefined> = ref(undefined)
   public errored: Ref<boolean> = ref(false)
   public error: Ref<unknown> = ref(null)
 
   private readonly channel: Channel<T>
 
-  public constructor(channel: Channel<T>, options: SubscriptionOptions) {
+  public constructor(channel: Channel<T>, options: SubscriptionOptions, response?: ActionResponse<T>) {
     this.id = SubscriptionIdManager.get()
     this.channel = channel
     this.options = options
+    this.response.value = response
   }
 
   public async refresh(): Promise<void> {

--- a/src/subscribe/utilities.ts
+++ b/src/subscribe/utilities.ts
@@ -1,8 +1,22 @@
-import { unref } from 'vue'
+import { isReactive, isRef, unref, WatchSource } from 'vue'
 import { Action, ActionArguments } from './types'
 
 export function unrefArgs<T extends Action>(args: ActionArguments<T>): Parameters<T> {
   const argsUnref = unref(args) as Parameters<T>
 
   return argsUnref.map(unref) as Parameters<T>
+}
+
+export function watchableArgs<T extends Action>(args: ActionArguments<T>): WatchSource | WatchSource[] {
+  if (isRef(args) || isReactive(args)) {
+    // can't quite figure out the types here. But the method is accurate best I can tell
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return args as any
+  }
+
+  if (Array.isArray(args)) {
+    return args.filter(arg => isRef(arg) || isReactive(arg))
+  }
+
+  return []
 }

--- a/src/subscribe/utilities.ts
+++ b/src/subscribe/utilities.ts
@@ -9,7 +9,7 @@ export function unrefArgs<T extends Action>(args: ActionArguments<T>): Parameter
 
 export function watchableArgs<T extends Action>(args: ActionArguments<T>): WatchSource | WatchSource[] {
   if (isRef(args) || isReactive(args)) {
-    // can't quite figure out the types here. But the method is accurate best I can tell
+    // can't quite figure out the types here. But the tests around reactive arguments pass so I believe this is correct
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return args as any
   }

--- a/tests/subscribe/useSubscription.spec.ts
+++ b/tests/subscribe/useSubscription.spec.ts
@@ -408,8 +408,6 @@ describe('subscribe', () => {
     jest.runAllTimers()
     jest.useRealTimers()
 
-    await timeout()
-
     valueArg.value = 1
 
     await timeout()

--- a/tests/subscribe/useSubscription.spec.ts
+++ b/tests/subscribe/useSubscription.spec.ts
@@ -155,8 +155,8 @@ describe('subscribe', () => {
     const maxInterval = 20
 
     const subscription1 = useSubscription(action, [], { interval: minInterval }, manager)
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const subscription2 = useSubscription(action, [], { interval: maxInterval }, manager)
+
+    useSubscription(action, [], { interval: maxInterval }, manager)
 
     subscription1.unsubscribe()
 
@@ -175,8 +175,8 @@ describe('subscribe', () => {
 
     const subscription1 = useSubscription(action, [], { interval: minInterval }, manager)
     const subscription2 = useSubscription(action, [], { interval: maxInterval }, manager)
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const subscription3 = useSubscription(action, [], {}, manager)
+
+    useSubscription(action, [], {}, manager)
 
     subscription1.unsubscribe()
     subscription2.unsubscribe()
@@ -415,6 +415,22 @@ describe('subscribe', () => {
     await timeout()
 
     expect(subscription.response.value).toBe(originalValue)
+  })
+
+  it('correctly sets response on additional subscriptions', async () => {
+    function action(): number {
+      return 0
+    }
+
+    const manager = new Manager()
+
+    useSubscription(action, [], {}, manager)
+
+    await timeout()
+
+    const subscription = useSubscription(action, [], {}, manager)
+
+    expect(subscription.response.value).toBe(0)
   })
 
 })

--- a/tests/subscribe/useSubscription.spec.ts
+++ b/tests/subscribe/useSubscription.spec.ts
@@ -366,4 +366,27 @@ describe('subscribe', () => {
 
   })
 
+  it('it does not return undefined when a subscription changes', async () => {
+    jest.useFakeTimers()
+
+    function action(value: number): Promise<number> {
+      return new Promise((resolve) => setTimeout(() => resolve(value), 100))
+    }
+
+    const originalValue = 0
+    const valueArg = ref(originalValue)
+    const subscription = useSubscription(action, [valueArg])
+
+    jest.runAllTimers()
+    jest.useRealTimers()
+
+    await timeout()
+
+    valueArg.value = 1
+
+    await timeout()
+
+    expect(subscription.response.value).toBe(originalValue)
+  })
+
 })

--- a/tests/subscribe/useSubscription.spec.ts
+++ b/tests/subscribe/useSubscription.spec.ts
@@ -258,10 +258,38 @@ describe('subscribe', () => {
       expect(action).toBeCalledTimes(2)
     })
 
+    it('when using args containing a ref value and a non reactive value', async () => {
+      const action = jest.fn()
+      const number = ref(0)
+      const args = [number, 0]
+
+      uniqueSubscribe(action, args)
+
+      number.value = 1
+
+      await timeout()
+
+      expect(action).toBeCalledTimes(2)
+    })
+
     it('when using args containing a reactive value', async () => {
       const action = jest.fn()
       const argument = reactive({ number: 0 })
       const args = [argument]
+
+      uniqueSubscribe(action, args)
+
+      argument.number = 1
+
+      await timeout()
+
+      expect(action).toBeCalledTimes(2)
+    })
+
+    it('when using args containing a reactive value and a non reactive value', async () => {
+      const action = jest.fn()
+      const argument = reactive({ number: 0 })
+      const args = [argument, 0]
 
       uniqueSubscribe(action, args)
 


### PR DESCRIPTION
# Description
When a subscription contains reactive arguments a couple of unexpected things can happen.

1. When arguments change the subscriptions channel changes. If a new channel has been created the subscriptions response would be undefined until the action resolves. 

2. When a new subscription to an existing channel is creating the response is undefined until the action is executed again.

3. If not all the arguments are reactive, vue would log a warning in the console. Ultimately the subscription was working as expected (we don't want vue to update the subscription if a non-reactive argument is changed anyway). But this causes confusion.

## Solution to undefined subscription responses to new channels
When a subscriptions channel is changed, if that channel is new it's response will be `undefined`. When that is the case, retain the previous channels response. That way the response smoothly transitions from channel to channel rather than reverting to `undefined` response in between.

## Solution to undefined subscription response existing channels
Storing the response on the channel and passing it to the new subscription when it is created. This means a subscription to an existing channel immediately receives the existing response. 

## Solution to vue watch warnings on arguments
Filter down the arguments to only those that are watchable. That way vue isn't asked to watch an argument it cannot that isn't expected to be watch anyway.
