### PR TITLE
Make manager part of the subscription options

### DIFF
--- a/src/subscribe/README.md
+++ b/src/subscribe/README.md
@@ -23,6 +23,7 @@ When a subscription is removed the channel interval is recalculated. A subscript
 | action  | `(...args: any[]) => any` | True | | The function to be executed
 | args    | `Parameters<action>`      | True | | Parameters of the action being executed
 | options.interval | `number`    | False | `Infinity` | A max poll interval in milliseconds.
+| options.manager | `Manager`    | False | `defaultManager` | A channel manager to use for the subscription.
 
 ## Returns
 | Name        | Type                                | Default     | Description                                                     |

--- a/src/subscribe/subscribe.ts
+++ b/src/subscribe/subscribe.ts
@@ -9,15 +9,14 @@ const defaultManager = new Manager()
 /**
  * @deprecated use useSubscription instead
  */
-// I don't think this method makes sense with 3 params
-// eslint-disable-next-line max-params
 export function subscribe<T extends Action>(
   action: T,
   args: ActionArguments<T>,
   options: SubscriptionOptions = {},
-  manager: Manager = defaultManager,
 ): Subscription<T> {
+  const manager = options.manager ?? defaultManager
   const subscription = shallowReactive(manager.subscribe(action, args, options))
+
   let unwatch: ReturnType<typeof watch> | undefined
 
   if (
@@ -61,10 +60,9 @@ export function subscribe<T extends Action>(
   return subscription
 }
 
-export function useSubscription<T extends Action>(...[action, args, options, manager]: SubscribeArguments<T>): Subscription<T> {
+export function useSubscription<T extends Action>(...[action, args, options]: SubscribeArguments<T>): Subscription<T> {
   const argsWithDefault = args ?? ([] as unknown as ActionArguments<T>)
   const optionsWithDefault = options ?? {}
-  const managerWithDefault = manager ?? defaultManager
 
-  return subscribe(action, argsWithDefault, optionsWithDefault, managerWithDefault)
+  return subscribe(action, argsWithDefault, optionsWithDefault)
 }

--- a/src/subscribe/types.ts
+++ b/src/subscribe/types.ts
@@ -16,11 +16,12 @@ export type ChannelSignature = `${number}-${string}`
 
 export type SubscriptionOptions = {
   interval?: number,
+  manager?: Manager,
 }
 
 type OnlyRequired<T extends any[], U extends any[] = []> = Partial<T> extends T ? U : T extends [infer F, ...infer R] ? OnlyRequired<R, [...U, F]> : U
 type ActionParamsRequired<T extends Action> = OnlyRequired<Parameters<T>>
 
 export type SubscribeArguments<T extends Action> = ActionParamsRequired<T> extends never[]
-  ? [action: T, args?: ActionArguments<T>, options?: SubscriptionOptions, manager?: Manager ]
-  : [action: T, args: ActionArguments<T>, options?: SubscriptionOptions, manager?: Manager ]
+  ? [action: T, args?: ActionArguments<T>, options?: SubscriptionOptions ]
+  : [action: T, args: ActionArguments<T>, options?: SubscriptionOptions ]

--- a/tests/subscribe/useSubscription.spec.ts
+++ b/tests/subscribe/useSubscription.spec.ts
@@ -120,8 +120,8 @@ describe('subscribe', () => {
     const manager = new Manager()
     const action = jest.fn()
 
-    useSubscription(action, [], {}, manager)
-    useSubscription(action, [], {}, manager)
+    useSubscription(action, [], { manager })
+    useSubscription(action, [], { manager })
 
     expect(action).toBeCalledTimes(1)
   })
@@ -136,8 +136,8 @@ describe('subscribe', () => {
     const minInterval = 10
     const maxInterval = 20
 
-    useSubscription(action, [], { interval: minInterval }, manager)
-    useSubscription(action, [], { interval: maxInterval }, manager)
+    useSubscription(action, [], { interval: minInterval, manager })
+    useSubscription(action, [], { interval: maxInterval, manager })
 
     jest.advanceTimersByTime(additionalExecutions * minInterval)
 
@@ -154,9 +154,9 @@ describe('subscribe', () => {
     const minInterval = 10
     const maxInterval = 20
 
-    const subscription1 = useSubscription(action, [], { interval: minInterval }, manager)
+    const subscription1 = useSubscription(action, [], { interval: minInterval, manager })
 
-    useSubscription(action, [], { interval: maxInterval }, manager)
+    useSubscription(action, [], { interval: maxInterval, manager })
 
     subscription1.unsubscribe()
 
@@ -173,10 +173,10 @@ describe('subscribe', () => {
     const minInterval = 10
     const maxInterval = 20
 
-    const subscription1 = useSubscription(action, [], { interval: minInterval }, manager)
-    const subscription2 = useSubscription(action, [], { interval: maxInterval }, manager)
+    const subscription1 = useSubscription(action, [], { interval: minInterval, manager })
+    const subscription2 = useSubscription(action, [], { interval: maxInterval, manager })
 
-    useSubscription(action, [], {}, manager)
+    useSubscription(action, [], { manager })
 
     subscription1.unsubscribe()
     subscription2.unsubscribe()
@@ -340,8 +340,8 @@ describe('subscribe', () => {
       return ++int
     }
 
-    const subscription1 = useSubscription(action, [], {}, manager)
-    const subscription2 = useSubscription(action, [], {}, manager)
+    const subscription1 = useSubscription(action, [], { manager })
+    const subscription2 = useSubscription(action, [], { manager })
 
     await timeout()
 
@@ -422,11 +422,11 @@ describe('subscribe', () => {
 
     const manager = new Manager()
 
-    useSubscription(action, [], {}, manager)
+    useSubscription(action, [], { manager })
 
     await timeout()
 
-    const subscription = useSubscription(action, [], {}, manager)
+    const subscription = useSubscription(action, [], { manager })
 
     expect(subscription.response.value).toBe(0)
   })

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -12,5 +12,10 @@ export function uniqueSubscribe<T extends Action>(
   args: ActionArguments<T>,
   options: SubscriptionOptions = {},
 ): Subscription<T> {
-  return useSubscription(action, args, options, new Manager())
+  const optionsWithManager = {
+    ...options,
+    manager: new Manager(),
+  }
+
+  return useSubscription(action, args, optionsWithManager)
 }


### PR DESCRIPTION
# Description
Reduce the number of arguments of subscribe by moving the `manager` argument into the `options` arguments. Make wrapping subscribe in other projects simpler.