### PR TITLE
Stop interval if action errors

### DIFF
--- a/src/subscribe/channel.ts
+++ b/src/subscribe/channel.ts
@@ -159,12 +159,20 @@ export default class Channel<T extends Action = Action> {
     }
   }
 
-  private setInterval(): void {
+  private clearTimer(): void {
     if (this.timer) {
       clearTimeout(this.timer)
     }
+  }
+
+  private setInterval(): void {
+    this.clearTimer()
 
     if (this.interval === Infinity) {
+      return
+    }
+
+    if (this.errored) {
       return
     }
 

--- a/src/subscribe/subscription.ts
+++ b/src/subscribe/subscription.ts
@@ -22,11 +22,16 @@ export default class Subscription<T extends Action> {
 
   private readonly channel: Channel<T>
 
-  public constructor(channel: Channel<T>, options: SubscriptionOptions, response?: ActionResponse<T>) {
+  public constructor(channel: Channel<T>, options: SubscriptionOptions) {
     this.id = SubscriptionIdManager.get()
     this.channel = channel
     this.options = options
-    this.response.value = response
+
+    this.loading.value = channel.loading
+    this.response.value = channel.response
+    this.errored.value = channel.errored
+    this.error.value = channel.error
+    this.executed.value = channel.executed
   }
 
   public async refresh(): Promise<void> {

--- a/tests/subscribe/useSubscription.spec.ts
+++ b/tests/subscribe/useSubscription.spec.ts
@@ -452,4 +452,18 @@ describe('subscribe', () => {
     expect(subscription.executed).toBe(true)
   })
 
+  it('stops executing when action errors', () => {
+    const action = jest.fn(() => {
+      throw 'error'
+    })
+
+    jest.useFakeTimers()
+
+    uniqueSubscribe(action, [], { interval: 10000 })
+
+    jest.advanceTimersByTime(10000 * 2)
+
+    expect(action).toBeCalledTimes(1)
+  })
+
 })


### PR DESCRIPTION
# Description
If an action throws an error we don't need to keep executing the action as the response will not change. 

Also modified how channels and subscriptions keep track of the public date (loading, executed, response, etc) so that the channel has a copy. That way when a subscription is created it can be created with the data the channel already has. Previously only response and executed were populated when a subscription was created. 