### PR TITLE
Feature: new composition `useElementWidth

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ npm i --save @prefecthq/vue-compositions
 - [useMedia](https://github.com/PrefectHQ/vue-compositions/tree/main/src/useMedia)
 - [useResizeObserver](https://github.com/PrefectHQ/vue-compositions/tree/main/src/useResizeObserver)
 - [useSubscription](https://github.com/PrefectHQ/vue-compositions/tree/main/src/useSubscription)
+- [useElementWidth](https://github.com/PrefectHQ/vue-compositions/tree/main/src/useElementWidth)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from './useElementWidth'
 export * from './useIntersectionObserver'
 export * from './useMedia'
 export * from './useResizeObserver'

--- a/src/useElementWidth/README.md
+++ b/src/useElementWidth/README.md
@@ -1,0 +1,18 @@
+# useElementWidth
+The `useElementWidth` composition abstracts away the logic for tracking the client width of an HTMLElement, even when the client width changes on resize thanks to `useResizeObserver`.
+
+## Example
+```typescript
+import { useElementWidth } from '@prefecthq/vue-compositions'
+
+const templateRef = ref<HTMLElement | undefined>()
+const widthInPx = useElementWidth(templateRef)
+```
+
+## Arguments
+| Name     | Type                              |
+|----------|-----------------------------------|
+| element | `HTMLElement \| undefined \| Ref<HTMLElement \| undefined>` |
+
+## Returns
+`Ref<number>` (in px)

--- a/src/useElementWidth/README.md
+++ b/src/useElementWidth/README.md
@@ -1,5 +1,5 @@
 # useElementWidth
-The `useElementWidth` composition abstracts away the logic for tracking the client width of an HTMLElement, even when the client width changes on resize thanks to `useResizeObserver`.
+The `useElementWidth` composition abstracts away the logic for tracking the client width of an HTMLElement, even when the client width changes on resize thanks to [useResizeObserver](https://github.com/PrefectHQ/vue-compositions/tree/main/src/useResizeObserver).
 
 ## Example
 ```typescript

--- a/src/useElementWidth/index.ts
+++ b/src/useElementWidth/index.ts
@@ -1,0 +1,1 @@
+export * from './useElementWidth'

--- a/src/useElementWidth/useElementWidth.ts
+++ b/src/useElementWidth/useElementWidth.ts
@@ -6,7 +6,6 @@ export function useElementWidth(element: HTMLElement | undefined | Ref<HTMLEleme
   const widthInPixels = ref<number>(0)
 
   const callback: UseResizeObserverCallback = function([entry]: ResizeObserverEntry[]) {
-    console.log({ callback: entry })
     const { width } = entry.target.getBoundingClientRect()
 
     widthInPixels.value = width
@@ -16,7 +15,6 @@ export function useElementWidth(element: HTMLElement | undefined | Ref<HTMLEleme
 
   watchEffect(() => {
     if (elementRef.value) {
-      console.log({ watch: elementRef.value })
       const { width } = elementRef.value.getBoundingClientRect()
 
       widthInPixels.value = width

--- a/src/useElementWidth/useElementWidth.ts
+++ b/src/useElementWidth/useElementWidth.ts
@@ -1,0 +1,29 @@
+import { ref, Ref, watchEffect } from 'vue'
+import { useResizeObserver, UseResizeObserverCallback } from '../useResizeObserver/useResizeObserver'
+
+export function useElementWidth(element: HTMLElement | undefined | Ref<HTMLElement | undefined>): Ref<number> {
+  const elementRef = ref(element)
+  const widthInPixels = ref<number>(0)
+
+  const callback: UseResizeObserverCallback = function([entry]: ResizeObserverEntry[]) {
+    console.log({ callback: entry })
+    const { width } = entry.target.getBoundingClientRect()
+
+    widthInPixels.value = width
+  }
+
+  const observer = useResizeObserver(callback)
+
+  watchEffect(() => {
+    if (elementRef.value) {
+      console.log({ watch: elementRef.value })
+      const { width } = elementRef.value.getBoundingClientRect()
+
+      widthInPixels.value = width
+      observer.disconnect()
+      observer.observe(elementRef)
+    }
+  })
+
+  return widthInPixels
+}


### PR DESCRIPTION
# useElementWidth
The `useElementWidth` composition abstracts away the logic for tracking the client width of an HTMLElement, even when the client width changes on resize thanks to `useResizeObserver`.

## Example
```typescript
import { useElementWidth } from '@prefecthq/vue-compositions'

const templateRef = ref<HTMLElement | undefined>()
const widthInPx = useElementWidth(templateRef)
```

## Arguments
| Name     | Type                              |
|----------|-----------------------------------|
| element | `HTMLElement \| undefined \| Ref<HTMLElement \| undefined>` |

## Returns
`Ref<number>` (in px)