### PR TITLE
Remove useRouteQueryParam check on default value

### DIFF
--- a/src/useRouteQueryParam/useRouteQueryParam.ts
+++ b/src/useRouteQueryParam/useRouteQueryParam.ts
@@ -12,7 +12,7 @@ export function useRouteQueryParam(param: string, defaultValue: string | string[
   const valueRef = ref<string | string[]>(initialValue)
 
   watch(valueRef, (newValue, oldValue) => {
-    if (isSame(newValue, oldValue) || isSame(newValue, defaultValue)) {
+    if (isSame(newValue, oldValue)) {
       return
     }
 


### PR DESCRIPTION
This was leading to bugs where query params were never updated on refreshes or if a value was present at load but some logic changed it (e.g. user interaction)