### PR TITLE
Feature: useSubscription - Keep the executed value when args change

### DIFF
--- a/src/useSubscription/useSubscription.ts
+++ b/src/useSubscription/useSubscription.ts
@@ -30,7 +30,7 @@ export function useSubscription<T extends Action>(...[action, args, options = {}
       const newSubscription = manager.subscribe(action, argsWithDefault, options)
 
       newSubscription.response.value ??= subscriptionResponse.response
-      newSubscription.executed.value = subscriptionResponse.executed
+      newSubscription.executed.value = newSubscription.executed.value || subscriptionResponse.executed
 
       Object.assign(subscriptionResponse, mapSubscription(newSubscription))
     }, { deep: true })

--- a/src/useSubscription/useSubscription.ts
+++ b/src/useSubscription/useSubscription.ts
@@ -30,7 +30,7 @@ export function useSubscription<T extends Action>(...[action, args, options = {}
       const newSubscription = manager.subscribe(action, argsWithDefault, options)
 
       newSubscription.response.value ??= subscriptionResponse.response
-      newSubscription.executed.value = subscriptionResponse.executed || newSubscription.executed.value
+      newSubscription.executed.value = subscriptionResponse.executed
 
       Object.assign(subscriptionResponse, mapSubscription(newSubscription))
     }, { deep: true })

--- a/src/useSubscription/useSubscription.ts
+++ b/src/useSubscription/useSubscription.ts
@@ -19,6 +19,7 @@ export function useSubscription<T extends Action>(...[action, args, options = {}
   if (watchable !== null) {
     unwatch = watch(watchable, () => {
       // checking if args are null to support useSubscriptionWithDependencies
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (!subscriptionResponse.isSubscribed() || unref(argsWithDefault) === null) {
         unwatch!()
         return
@@ -29,6 +30,7 @@ export function useSubscription<T extends Action>(...[action, args, options = {}
       const newSubscription = manager.subscribe(action, argsWithDefault, options)
 
       newSubscription.response.value ??= subscriptionResponse.response
+      newSubscription.executed.value = subscriptionResponse.executed || newSubscription.executed.value
 
       Object.assign(subscriptionResponse, mapSubscription(newSubscription))
     }, { deep: true })


### PR DESCRIPTION
# Description
Previously when using `useSubscription` you would get a completely fresh subscription except for the `response`. If the previous subscription had a response it would get copied over to the new subscription. This preserved the response until the new subscription was executed.

This PR adds that same behavior to the `executed` property. This is useful because frequently `executed` is used to determine if a subscriptions action has been called at least once without having to care about what the response is. 

Preserving the `executed` property even when args change makes more sense also because `executed` applies to the action and the action for a subscription cannot be changed. 

## Note
Its worth noting that this does not yet apply to `useSubscriptionWithDependencies`. That composition will require some refactoring in order to support this change. 