### PR TITLE
Feature: Log errors to the console

### DIFF
--- a/src/useSubscription/models/channel.ts
+++ b/src/useSubscription/models/channel.ts
@@ -177,6 +177,8 @@ export default class Channel<T extends Action = Action> {
       this.errored = true
       this.error = error
       this.clearTimer()
+
+      console.error(error)
     } finally {
       this.executed = true
       this.loading = false


### PR DESCRIPTION
# Description
Subscriptions catch errors to prevent breaking reactivity. However this makes debugging difficult. Logging the error should make the developer experience better. 