### PR TITLE
chore: added support for the required mutation observe options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prefecthq/vue-compositions",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prefecthq/vue-compositions",
-      "version": "0.1.45",
+      "version": "0.1.46",
       "devDependencies": {
         "@prefecthq/eslint-config": "1.0.16",
         "@testing-library/vue": "^6.4.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@prefecthq/vue-compositions",
   "private": false,
-  "version": "0.1.45",
+  "version": "0.1.46",
   "description": "A collection of reusable vue compositions.",
   "main": "index.ts",
   "scripts": {

--- a/src/useComputedStyle/useComputedStyle.ts
+++ b/src/useComputedStyle/useComputedStyle.ts
@@ -13,7 +13,7 @@ export function useComputedStyle(element: Element | Ref<Element | undefined>): T
       Object.assign(style, window.getComputedStyle(element, null))
 
       mutationObserver.disconnect()
-      mutationObserver.observe(elementRef)
+      mutationObserver.observe(elementRef, { attributes: true })
       resizeObserver.disconnect()
       resizeObserver.observe(elementRef)
     }

--- a/src/useMutationObserver/README.md
+++ b/src/useMutationObserver/README.md
@@ -17,6 +17,7 @@ const observer = useMutationObserver(callback)
 | Name     | Type                        |
 |----------|-----------------------------|
 | callback | `MutationCallback` |
+| options | `MutationObserverInit` |
 
 ## Returns
 `UseMutationObserverResponse`

--- a/src/useMutationObserver/useMutationObserver.ts
+++ b/src/useMutationObserver/useMutationObserver.ts
@@ -1,21 +1,21 @@
 import { onMounted, onUnmounted, ref, Ref } from 'vue'
 
 export type UseMutationObserverResponse = {
-  observe: (element: Element | Ref<Element | undefined>) => void,
+  observe: (element: Element | Ref<Element | undefined>, options: MutationObserverInit) => void,
   disconnect: () => void,
-  check: (element: Element | Ref<Element | undefined>) => void,
+  check: (element: Element | Ref<Element | undefined>, options: MutationObserverInit) => void,
 }
 
 export function useMutationObserver(callback: MutationCallback): UseMutationObserverResponse {
 
   let mutationObserver: MutationObserver | null = null
 
-  const observe: UseMutationObserverResponse['observe'] = (element) => {
+  const observe: UseMutationObserverResponse['observe'] = (element, options) => {
     const elementRef = ref(element)
     const observer = getObserver()
 
     if (elementRef.value) {
-      observer.observe(elementRef.value)
+      observer.observe(elementRef.value, options)
     }
   }
 
@@ -25,7 +25,7 @@ export function useMutationObserver(callback: MutationCallback): UseMutationObse
     observer.disconnect()
   }
 
-  const check: UseMutationObserverResponse['check'] = (element) => {
+  const check: UseMutationObserverResponse['check'] = (element, options) => {
     const elementRef = ref(element)
     if (!elementRef.value) {
       return
@@ -33,7 +33,7 @@ export function useMutationObserver(callback: MutationCallback): UseMutationObse
 
     const observer = new MutationObserver(callback)
 
-    observer.observe(elementRef.value)
+    observer.observe(elementRef.value, options)
 
     setTimeout(() => observer.disconnect(), 100)
   }


### PR DESCRIPTION
as documented under `options`, at least one is required else an error is thrown
https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/observe

<img width="1471" alt="image" src="https://user-images.githubusercontent.com/6098901/189793161-d6f22fb1-cf07-4726-a2de-fe4bf5409935.png">
