### PR TITLE
BugFix: support nullable types in useStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,16 @@ npm i --save @prefecthq/vue-compositions
 ```
 
 ## Compositions
-- [useDebouncedRef](https://github.com/PrefectHQ/vue-compositions/tree/main/src/useDebouncedRef)
-- [useElementRect](https://github.com/PrefectHQ/vue-compositions/tree/main/src/useElementRect)
-- [useIntersectionObserver](https://github.com/PrefectHQ/vue-compositions/tree/main/src/useIntersectionObserver)
-- [useMedia](https://github.com/PrefectHQ/vue-compositions/tree/main/src/useMedia)
-- [useResizeObserver](https://github.com/PrefectHQ/vue-compositions/tree/main/src/useResizeObserver)
-- [useRouteQueryParam](https://github.com/PrefectHQ/vue-compositions/tree/main/src/useRouteQueryParam)
-- [useSubscription](https://github.com/PrefectHQ/vue-compositions/tree/main/src/useSubscription)
+- [useChildrenAreWrapped](https://github.com/prefecthq/vue-compositions/tree/main/src/useChildrenAreWrapped)
+- [useComputedStyle](https://github.com/prefecthq/vue-compositions/tree/main/src/useComputedStyle)
+- [useDebouncedRef](https://github.com/prefecthq/vue-compositions/tree/main/src/useDebouncedRef)
+- [useElementRect](https://github.com/prefecthq/vue-compositions/tree/main/src/useElementRect)
+- [useElementWidth](https://github.com/prefecthq/vue-compositions/tree/main/src/useElementWidth)
+- [useIntersectionObserver](https://github.com/prefecthq/vue-compositions/tree/main/src/useIntersectionObserver)
+- [useMedia](https://github.com/prefecthq/vue-compositions/tree/main/src/useMedia)
+- [useMutationObserver](https://github.com/prefecthq/vue-compositions/tree/main/src/useMutationObserver)
+- [useResizeObserver](https://github.com/prefecthq/vue-compositions/tree/main/src/useResizeObserver)
+- [useRouteParam](https://github.com/prefecthq/vue-compositions/tree/main/src/useRouteParam)
+- [useRouteQueryParam](https://github.com/prefecthq/vue-compositions/tree/main/src/useRouteQueryParam)
+- [useStorage](https://github.com/prefecthq/vue-compositions/tree/main/src/useStorage)
+- [useSubscription](https://github.com/prefecthq/vue-compositions/tree/main/src/useSubscription)

--- a/src/useStorage/README.md
+++ b/src/useStorage/README.md
@@ -5,25 +5,25 @@ The `useStorage` composition is a reactive wrapper around localStorage and sessi
 ```typescript
 import { useStorage } from '@prefecthq/vue-compositions'
 
-const { values: foo } = useStorage('local', 'foo') // type is `unknown`
-const { values: bar } = useStorage<boolean>('local', 'bar') // type is `boolean`
-const { values: bas } = useStorage('local', 'bas', false) // type 'boolean'
+const { value: foo } = useStorage('local', 'foo') // type is `unknown`
+const { value: bar } = useStorage<boolean>('local', 'bar') // type is `boolean`
+const { value: bas } = useStorage('local', 'bas', false) // type 'boolean'
 ```
 Two additional compositions are exported as a convenience for each type of storage. `useLocalStorage` and `useSessionStorage`. 
 ```typescript
 import { useLocalStorage, useSessionStorage } from '@prefecthq/vue-compositions'
 
 // this
-const { values: foo } = useLocalStorage('foo')
+const { value: foo } = useLocalStorage('foo')
 
 // is the same as this
-const { values: foo } = useStorage('local', 'foo')
+const { value: foo } = useStorage('local', 'foo')
 
 // and this
-const { values: foo } = useSessionStorage('foo')
+const { value: foo } = useSessionStorage('foo')
 
 // is the same as this
-const { values: foo } = useStorage('session', 'foo')
+const { value: foo } = useStorage('session', 'foo')
 
 ```
 

--- a/src/useStorage/useStorage.ts
+++ b/src/useStorage/useStorage.ts
@@ -6,22 +6,29 @@ type UseStorage<T> = {
   value: Ref<UnwrapRef<T>>,
   initialValue: T,
   remove: () => void,
-  set: (value: NonNullable<UnwrapRef<T>>) => void,
+  set: (value: UnwrapRef<T>) => void,
 }
 
-export function useStorage<T>(type: StorageType, key: string): UseStorage<T | null>
+type UseNullableStorage<T> = {
+  value: Ref<UnwrapRef<T> | null>,
+  initialValue: T | null,
+  remove: () => void,
+  set: (value: UnwrapRef<T> | null) => void,
+}
+
+export function useStorage<T>(type: StorageType, key: string): UseNullableStorage<T>
 export function useStorage<T>(type: StorageType, key: string, defaultValue: T): UseStorage<T>
-export function useStorage<T>(type: StorageType, key: string, defaultValue: T | null = null): UseStorage<T | null> {
+export function useStorage<T>(type: StorageType, key: string, defaultValue: T | null = null): UseNullableStorage<T> {
   const storage = new StorageManager(type)
   const initialValue = storage.get(key, defaultValue)
   const data = ref(initialValue)
 
-  const remove = (): void => {
+  const remove: UseNullableStorage<T>['remove'] = () => {
     storage.remove(key)
     data.value = null
   }
 
-  const set = (value: NonNullable<UnwrapRef<T>>): void => {
+  const set: UseNullableStorage<T>['set'] = (value) => {
     data.value = value
   }
 


### PR DESCRIPTION
previously, if you defined T as `const {set} = useLocalStorage<number | null>('key')`

the `set` method would not accept `null` as a valid argument, even though T claims to support null.

