### PR TITLE
BugFix: useStorage better support transferring old storage values

### DIFF
--- a/src/useStorage/storage.ts
+++ b/src/useStorage/storage.ts
@@ -37,6 +37,7 @@ export class StorageManager {
     try {
       return JSON.parse(value) as T
     } catch {
+      console.error(`Unable to parse current value for key ${key}, returning default instead`)
       return defaultValue
     }
   }

--- a/src/useStorage/storage.ts
+++ b/src/useStorage/storage.ts
@@ -34,7 +34,11 @@ export class StorageManager {
       return defaultValue
     }
 
-    return JSON.parse(value) as T
+    try {
+      return JSON.parse(value) as T
+    } catch {
+      return defaultValue
+    }
   }
 
   public set<T>(key: string, value: T): void {


### PR DESCRIPTION
if useStorage is used on previously saved value, this will prevent console error and allow safe transition

for example, color mode was previously saved to localStorage with simple

```ts
localStorage.setItem(colorModeLocalStorageKey, mode)
// mode is string, like 'achromatopsia'
```

if your user had 'achromatopsia' in localStorage, and you try updating to useStorage

```ts
const { value } = useStorage(colorModeLocalStorageKey)
```

you'll get the error

> Uncaught SyntaxError: Unexpected token 'a', "achromatopsia" is not valid JSON

with this PR, you'll be able to write 

```ts
const nonJsonVersion = localStorage.getItem(colorModeLocalStorageKey)
const defaultValue = isColorMode(nonJsonVersion) ? nonJsonVersion : null
```

which safely transfers the `nonJsonVersion` in