### PR TITLE
BugFix: useStorage - Prevent future updates to storage once remove has been called

### DIFF
--- a/src/useStorage/useStorage.ts
+++ b/src/useStorage/useStorage.ts
@@ -22,8 +22,10 @@ export function useStorage<T>(type: StorageType, key: string, defaultValue: T | 
   const storage = new StorageManager(type)
   const initialValue = storage.get(key, defaultValue)
   const data = ref(initialValue)
+  let stopped = false
 
   const remove: UseNullableStorage<T>['remove'] = () => {
+    stopped = true
     storage.remove(key)
     data.value = null
   }
@@ -33,6 +35,11 @@ export function useStorage<T>(type: StorageType, key: string, defaultValue: T | 
   }
 
   watchEffect(() => {
+    if (stopped) {
+      console.warn(`Storage for key ${key} as been removed and cannot be updated`)
+      return
+    }
+
     storage.set(key, data.value)
   })
 


### PR DESCRIPTION
# Description
Fixes a bug where calling `remove` on storage adds the key back with the string `null`

Related to https://github.com/PrefectHQ/nebula-ui/issues/1893