### PR TITLE
Chore: Remove changelog from the release workflow and add release npm scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Create Release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PREFECT__GITHUB_ACTIONS_UI_TOKEN }}
         with:
           tag_name: ${{ steps.publish.outputs.version }}
           release_name: Release ${{ steps.publish.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,13 +36,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Read .nvmrc
-        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
-        id: nvm
-
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: "${{ steps.nvm.outputs.NVMRC }}"
+          node-version-file: ".nvmrc"
       
       - name: Install dependencies
         run: npm ci install
@@ -50,18 +46,6 @@ jobs:
       - name: Get Package Version
         uses: EndBug/version-check@v2.1.0
         id: version
-
-      - name: Generate Changelog
-        run: npm run changelog
-      
-      - name: Commit Changelog
-        run: |
-          git pull
-          git config --global user.name 'Craig Harshbarger'
-          git config --global user.email 'pleek91@gmail.com'
-          git add CHANGELOG.md
-          git commit -am "Generate CHANGELOG.md"
-          git push
 
       - name: Publish Package
         id: publish

--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
     "lint": "eslint ./",
     "lint:fix": "eslint ./ --fix",
     "types": "vue-tsc --noEmit",
-    "changelog": "auto-changelog --package --commit-limit 0"
+    "changelog": "auto-changelog --package --commit-limit 0",
+    "changelog:commit": "npm run changelog && git add -A && git commit -m 'Update CHANGELOG.md'",
+    "release:patch": "npm version patch && npm run changelog:commit",
+    "release:minor": "npm version minor && npm run changelog:commit",
+    "release:major": "npm version major && npm run changelog:commit'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Mirroring what we've done in other repositories