### PR TITLE
Feature: Create useVisibilityObserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ npm i --save @prefecthq/vue-compositions
 - [useRouteQueryParam](https://github.com/prefecthq/vue-compositions/tree/main/src/useRouteQueryParam)
 - [useStorage](https://github.com/prefecthq/vue-compositions/tree/main/src/useStorage)
 - [useSubscription](https://github.com/prefecthq/vue-compositions/tree/main/src/useSubscription)
+- [useVisibilityObserver](https://github.com/prefecthq/vue-compositions/tree/main/src/useVisibilityObserver)

--- a/src/useVisibilityObserver/README.md
+++ b/src/useVisibilityObserver/README.md
@@ -6,7 +6,7 @@ The `useVisibilityObserver` composition is based on `useIntersectionObserver` co
 import { useVisibilityObserver } from '@prefecthq/vue-compositions'
 
 const element = ref<HTMLDivElement>()
-  const { visible } = useVisibilityObserver(element)
+const { visible } = useVisibilityObserver(element)
 ```
 
 ## Arguments

--- a/src/useVisibilityObserver/README.md
+++ b/src/useVisibilityObserver/README.md
@@ -1,0 +1,18 @@
+# useVisibilityObserver
+The `useVisibilityObserver` composition is based on `useIntersectionObserver` composition and after abstracting away the logic for creating and connecting an [IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/IntersectionObserver), returns boolean value if target element is visible.
+
+## Example
+```typescript
+import { useVisibilityObserver } from '@prefecthq/vue-compositions'
+
+const element = ref<HTMLDivElement>()
+const visible = useVisibility(element)
+```
+
+## Arguments
+| Name  | Type                    |
+|-------|-------------------------|
+| element | `Ref<HTMLElement>` |
+
+## Returns
+`Ref<boolean>`

--- a/src/useVisibilityObserver/README.md
+++ b/src/useVisibilityObserver/README.md
@@ -13,8 +13,7 @@ const { visible } = useVisibilityObserver(element)
 | Name  | Type                    |
 |-------|-------------------------|
 | element | `Ref<HTMLElement>` |
-| disconnectWhenVisible | `boolean` |
-| options  | `UseIntersectionObserverOptions`  |
+| options  | `UseVisibilityObserverOptions`  |
 
 ## Returns
 `UseVisibilityObserverResponse`

--- a/src/useVisibilityObserver/README.md
+++ b/src/useVisibilityObserver/README.md
@@ -6,13 +6,15 @@ The `useVisibilityObserver` composition is based on `useIntersectionObserver` co
 import { useVisibilityObserver } from '@prefecthq/vue-compositions'
 
 const element = ref<HTMLDivElement>()
-const visible = useVisibility(element)
+  const { visible } = useVisibilityObserver(element)
 ```
 
 ## Arguments
 | Name  | Type                    |
 |-------|-------------------------|
 | element | `Ref<HTMLElement>` |
+| disconnectWhenVisible | `boolean` |
+| options  | `UseIntersectionObserverOptions`  |
 
 ## Returns
-`Ref<boolean>`
+`UseVisibilityObserverResponse`

--- a/src/useVisibilityObserver/index.ts
+++ b/src/useVisibilityObserver/index.ts
@@ -1,0 +1,1 @@
+export * from './useVisibilityObserver'

--- a/src/useVisibilityObserver/useVisibilityObserver.ts
+++ b/src/useVisibilityObserver/useVisibilityObserver.ts
@@ -6,20 +6,24 @@ export type UseVisibilityObserverResponse = {
   disconnect: () => void,
 }
 
-export function useVisibilityObserver(element: Ref<HTMLElement | undefined>, disconnectWhenVisible: boolean = false, options: UseIntersectionObserverOptions = {}): UseVisibilityObserverResponse {
+export type UseVisibilityObserverOptions = UseIntersectionObserverOptions & { disconnectWhenVisible: boolean }
+
+export function useVisibilityObserver(element: Ref<HTMLElement | undefined>, options: UseVisibilityObserverOptions = { disconnectWhenVisible: false } ): UseVisibilityObserverResponse {
   const visible = ref(false)
 
   function intersect(entries: IntersectionObserverEntry[]): void {
     entries.forEach(entry => {
-        visible.value = entry.isIntersecting
+      visible.value = entry.isIntersecting
 
-        if (disconnectWhenVisible) {
-          disconnect()
-        }
+      if (options.disconnectWhenVisible && entry.isIntersecting) {
+        disconnect()
+      }
     })
   }
 
-  const { observe, disconnect } = useIntersectionObserver(intersect, options)
+  const { root, rootMargin, threshold } = options
+
+  const { observe, disconnect } = useIntersectionObserver(intersect, { root, rootMargin, threshold })
 
   onMounted(() => {
     observe(element)

--- a/src/useVisibilityObserver/useVisibilityObserver.ts
+++ b/src/useVisibilityObserver/useVisibilityObserver.ts
@@ -1,24 +1,29 @@
 import { onMounted, ref, Ref } from 'vue'
-import { useIntersectionObserver } from '@/useIntersectionObserver'
+import { useIntersectionObserver, UseIntersectionObserverOptions } from '@/useIntersectionObserver'
 
-export function useVisibilityObserver(element: Ref<HTMLElement | undefined>): Ref<boolean> {
+export type UseVisibilityObserverResponse = {
+  visible: Ref<boolean>,
+  disconnect: () => void,
+}
+
+export function useVisibilityObserver(element: Ref<HTMLElement | undefined>, disconnectWhenVisible: boolean = false, options: UseIntersectionObserverOptions = {}): UseVisibilityObserverResponse {
   const visible = ref(false)
 
   function intersect(entries: IntersectionObserverEntry[]): void {
     entries.forEach(entry => {
-      if (entry.isIntersecting) {
-        visible.value = true
-        disconnect()
-      }
+        visible.value = entry.isIntersecting
+
+        if (disconnectWhenVisible) {
+          disconnect()
+        }
     })
   }
 
-  const { observe, disconnect } = useIntersectionObserver(intersect)
+  const { observe, disconnect } = useIntersectionObserver(intersect, options)
 
   onMounted(() => {
     observe(element)
   })
 
-  return visible
+  return { visible, disconnect }
 }
-

--- a/src/useVisibilityObserver/useVisibilityObserver.ts
+++ b/src/useVisibilityObserver/useVisibilityObserver.ts
@@ -10,20 +10,19 @@ export type UseVisibilityObserverOptions = UseIntersectionObserverOptions & { di
 
 export function useVisibilityObserver(element: Ref<HTMLElement | undefined>, options: UseVisibilityObserverOptions = { disconnectWhenVisible: false }): UseVisibilityObserverResponse {
   const visible = ref(false)
+  const { disconnectWhenVisible, ...intersectionObserverOptions } = options
 
   function intersect(entries: IntersectionObserverEntry[]): void {
     entries.forEach(entry => {
       visible.value = entry.isIntersecting
 
-      if (options.disconnectWhenVisible && entry.isIntersecting) {
+      if (disconnectWhenVisible && entry.isIntersecting) {
         disconnect()
       }
     })
   }
 
-  const { root, rootMargin, threshold } = options
-
-  const { observe, disconnect } = useIntersectionObserver(intersect, { root, rootMargin, threshold })
+  const { observe, disconnect } = useIntersectionObserver(intersect, intersectionObserverOptions)
 
   onMounted(() => {
     observe(element)

--- a/src/useVisibilityObserver/useVisibilityObserver.ts
+++ b/src/useVisibilityObserver/useVisibilityObserver.ts
@@ -1,0 +1,25 @@
+
+import { useIntersectionObserver } from '@/useIntersectionObserver'
+import { onMounted, ref, Ref } from 'vue'
+
+export function useVisibilityObserver(element: Ref<HTMLElement | undefined>): Ref<boolean> {
+  const visible = ref(false)
+
+  function intersect(entries: IntersectionObserverEntry[]): void {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        visible.value = true
+        disconnect()
+      }
+    })
+  }
+
+  const { observe, disconnect } = useIntersectionObserver(intersect)
+
+  onMounted(() => {
+    observe(element)
+  })
+
+  return visible
+}
+

--- a/src/useVisibilityObserver/useVisibilityObserver.ts
+++ b/src/useVisibilityObserver/useVisibilityObserver.ts
@@ -8,7 +8,7 @@ export type UseVisibilityObserverResponse = {
 
 export type UseVisibilityObserverOptions = UseIntersectionObserverOptions & { disconnectWhenVisible: boolean }
 
-export function useVisibilityObserver(element: Ref<HTMLElement | undefined>, options: UseVisibilityObserverOptions = { disconnectWhenVisible: false } ): UseVisibilityObserverResponse {
+export function useVisibilityObserver(element: Ref<HTMLElement | undefined>, options: UseVisibilityObserverOptions = { disconnectWhenVisible: false }): UseVisibilityObserverResponse {
   const visible = ref(false)
 
   function intersect(entries: IntersectionObserverEntry[]): void {

--- a/src/useVisibilityObserver/useVisibilityObserver.ts
+++ b/src/useVisibilityObserver/useVisibilityObserver.ts
@@ -1,6 +1,5 @@
-
-import { useIntersectionObserver } from '@/useIntersectionObserver'
 import { onMounted, ref, Ref } from 'vue'
+import { useIntersectionObserver } from '@/useIntersectionObserver'
 
 export function useVisibilityObserver(element: Ref<HTMLElement | undefined>): Ref<boolean> {
   const visible = ref(false)


### PR DESCRIPTION
This PR adds the `useVisibilityObserver` composition that is based on `useIntersectionObserver` composition to abstract away the logic for creating and connecting an IntersectionObserver and returns a boolean value if the target element is visible