### PR TITLE
Enhancement: subscription promise types

### DIFF
--- a/src/useSubscription/models/subscription.ts
+++ b/src/useSubscription/models/subscription.ts
@@ -16,7 +16,7 @@ export default class Subscription<T extends Action> {
   public readonly id: number
   public readonly options: SubscriptionOptions
   public loading: Ref<boolean> = ref(false)
-  public response: Ref<ActionResponse<T>| undefined> = ref(undefined)
+  public response: Ref<ActionResponse<T> | undefined> = ref(undefined)
   public errored: Ref<boolean> = ref(false)
   public error: Ref<unknown> = ref(null)
   public executed: Ref<boolean> = ref(false)

--- a/src/useSubscription/models/subscription.ts
+++ b/src/useSubscription/models/subscription.ts
@@ -47,20 +47,21 @@ export default class Subscription<T extends Action> {
     return this.channel.isSubscribed(this.id)
   }
 
-  public promise(): Promise<Subscription<T>> {
+  public promise(): Promise<Subscription<T> & { response: Ref<ActionResponse<T>> }> {
     return new Promise((resolve, reject) => {
-      if (this.executed.value) {
+      if (this.isResolved()) {
         if (this.errored.value) {
           reject(this.error.value)
           return
         }
+
 
         resolve(this)
         return
       }
 
       const executedWatcher = watch(this.executed, () => {
-        if (this.executed.value) {
+        if (this.isResolved()) {
           erroredWatcher()
           executedWatcher()
           resolve(this)
@@ -75,5 +76,9 @@ export default class Subscription<T extends Action> {
         }
       })
     })
+  }
+
+  private isResolved(): this is { response: Ref<ActionResponse<T>> } {
+    return this.executed.value
   }
 }

--- a/src/useSubscription/types/subscription.ts
+++ b/src/useSubscription/types/subscription.ts
@@ -1,3 +1,4 @@
+import { Ref } from 'vue'
 import Manager from '@/useSubscription/models/manager'
 import Subscription from '@/useSubscription/models/subscription'
 import { Action, ActionArguments, ActionParamsRequired, ActionResponse } from '@/useSubscription/types/action'
@@ -11,6 +12,8 @@ export type SubscriptionOptions = {
   manager?: Manager,
 }
 
+export type SubscriptionPromise<T extends Action> = Promise<Omit<UseSubscription<T>, 'promise'> & { response: ActionResponse<T> }>
+
 export type MappedSubscription<T extends Action> = {
   loading: Subscription<T>['loading'],
   response: Subscription<T>['response'],
@@ -20,7 +23,7 @@ export type MappedSubscription<T extends Action> = {
   refresh: Subscription<T>['refresh'],
   unsubscribe: Subscription<T>['unsubscribe'],
   isSubscribed: Subscription<T>['isSubscribed'],
-  promise: () => Promise<UseSubscription<T>>,
+  promise: () => SubscriptionPromise<T>,
 }
 
 export type UseSubscription<T extends Action> = {
@@ -32,5 +35,5 @@ export type UseSubscription<T extends Action> = {
   refresh: Subscription<T>['refresh'],
   unsubscribe: Subscription<T>['unsubscribe'],
   isSubscribed: Subscription<T>['isSubscribed'],
-  promise: () => Promise<UseSubscription<T>>,
+  promise: () => SubscriptionPromise<T>,
 }

--- a/src/useSubscription/types/subscription.ts
+++ b/src/useSubscription/types/subscription.ts
@@ -1,4 +1,3 @@
-import { Ref } from 'vue'
 import Manager from '@/useSubscription/models/manager'
 import Subscription from '@/useSubscription/models/subscription'
 import { Action, ActionArguments, ActionParamsRequired, ActionResponse } from '@/useSubscription/types/action'

--- a/src/useSubscription/utilities/subscriptions.ts
+++ b/src/useSubscription/utilities/subscriptions.ts
@@ -15,6 +15,6 @@ export function mapSubscription<T extends Action>(subscription: Subscription<T>)
     refresh: () => subscription.refresh(),
     unsubscribe: () => subscription.unsubscribe(),
     isSubscribed: () => subscription.isSubscribed(),
-    promise: () => subscription.promise().then(subscription => reactive(mapSubscription(subscription))),
+    promise: () => subscription.promise().then(subscription => reactive(subscription)),
   }
 }


### PR DESCRIPTION
# Description
Fixes the types returned by the `promise` method on a subscription so that the response is not possibly undefined. 

```typescript
function action(): boolean {}

const { response } = await useSubscription(action).promise()

// before
response // boolean | undefined

// after
response // boolean