### PR TITLE
Enhancement: Support arrays in RouteQueryParamsSchema type

### DIFF
--- a/src/types/generics.ts
+++ b/src/types/generics.ts
@@ -1,3 +1,5 @@
 // https://github.com/microsoft/TypeScript/issues/14829#issuecomment-504042546
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type NoInfer<T> = [T][T extends any ? 0 : never]
+
+export type NonArray<T> = T extends (infer V)[] ? V : T

--- a/src/types/generics.ts
+++ b/src/types/generics.ts
@@ -1,5 +1,7 @@
+import { MaybeArray } from '@/types/maybe'
+
 // https://github.com/microsoft/TypeScript/issues/14829#issuecomment-504042546
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type NoInfer<T> = [T][T extends any ? 0 : never]
 
-export type NonArray<T> = T extends (infer V)[] ? V : T
+export type NonArray<T extends MaybeArray> = T extends (infer V)[] ? V : T

--- a/src/useRouteQueryParam/useRouteQueryParam.ts
+++ b/src/useRouteQueryParam/useRouteQueryParam.ts
@@ -22,7 +22,6 @@ export function useRouteQueryParam<T>(key: string, formatter: RouteParamClass<T>
 export function useRouteQueryParam<T>(key: string, formatter: RouteParamClass<T>, defaultValue: NoInfer<T>[]): Ref<T[]>
 export function useRouteQueryParam<T>(key: string, formatter: RouteParamClass<T>, defaultValue: MaybeArray<T>): Ref<MaybeArray<T>>
 export function useRouteQueryParam<T>(key: string, formatter: RouteParamClass<T>, defaultValue: MaybeArray<T> | undefined): Ref<MaybeArray<T> | undefined>
-
 export function useRouteQueryParam(key: string, formatterOrDefaultValue?: RouteParamClass | MaybeArray<string> | undefined, maybeDefaultValue?: MaybeArray | undefined): Ref {
 
   const isStringParamWithDefaultValue = isDefaultValue(formatterOrDefaultValue)

--- a/src/useRouteQueryParams/useRouteQueryParams.ts
+++ b/src/useRouteQueryParams/useRouteQueryParams.ts
@@ -1,5 +1,5 @@
 import { Ref } from 'vue'
-import { NoInfer } from '@/types/generics'
+import { NoInfer, NonArray } from '@/types/generics'
 import { isRouteParamClass, RouteParamClass } from '@/useRouteQueryParam/formats'
 import { useRouteQueryParam } from '@/useRouteQueryParam/useRouteQueryParam'
 
@@ -8,7 +8,7 @@ type AnyRecord = Record<string, unknown>
 export type RouteQueryParamsSchema<T extends AnyRecord> = {
   [P in keyof T]-?: NonNullable<T[P]> extends AnyRecord
     ? RouteQueryParamsSchema<NonNullable<T[P]>>
-    : RouteParamClass<NonNullable<T[P]>>
+    : RouteParamClass<NonNullable<NonArray<T[P]>>>
 }
 
 export type RouteQueryParams<T extends AnyRecord> = {
@@ -19,8 +19,8 @@ export type RouteQueryParams<T extends AnyRecord> = {
     : Ref<T[P]>
 }
 
-export function useRouteQueryParams<T extends AnyRecord>(schema: RouteQueryParamsSchema<T>, defaultValue: NoInfer<T>): RouteQueryParams<T> {
-  return getSchemaRouteQueryParams(schema, defaultValue)
+export function useRouteQueryParams<T extends AnyRecord>(schema: RouteQueryParamsSchema<T>, defaultValue: NoInfer<T>, prefix?: string): RouteQueryParams<T> {
+  return getSchemaRouteQueryParams(schema, defaultValue, prefix)
 }
 
 function isRouteParamSchema<T extends AnyRecord>(value: RouteQueryParamsSchema<T> | unknown): value is RouteQueryParamsSchema<T> {


### PR DESCRIPTION
# Description
`RouteQueryParamsSchema` didn't support params that were arrays. Introducing a `NonArray` generic type that is used to get the type for a `MaybeArray` and using that in the `RouteQueryParamsSchema` type. 

Also exposed the optional `prefix` argument in the `useRouteQueryParams` composition since that will be useful in implementation. 