### PR TITLE
Enhancement: Expand functionality of validation rules

### DIFF
--- a/src/useValidation/useValidation.ts
+++ b/src/useValidation/useValidation.ts
@@ -1,4 +1,4 @@
-import { computed, onMounted, onUnmounted, reactive, ref, ToRefs, watch, unref } from 'vue'
+import { computed, onMounted, onUnmounted, reactive, ref, ToRefs, watch, unref, Ref } from 'vue'
 import { NoInfer } from '@/types/generics'
 import { MaybeArray, MaybePromise, MaybeRef } from '@/types/maybe'
 import { ValidationAbortedError } from '@/useValidation/ValidationAbortedError'
@@ -16,12 +16,26 @@ export type UseValidationState = {
   validated: boolean,
 }
 
+type ValidateMethodOptions = {
+  source?: string,
+}
+
+type ValidateMethod = (options: ValidateMethodOptions) => Promise<boolean>
+
 export type UseValidation = ToRefs<UseValidationState> & {
-  validate: () => Promise<boolean>,
+  validate: ValidateMethod,
   state: UseValidationState,
 }
 
-export type ValidationRule<T> = (value: T, name: string, signal: AbortSignal) => MaybePromise<boolean | string>
+export type ValidationRuleSource = 'validation' | 'observer'
+
+export type ValidationRuleMeta<T> = {
+  signal: AbortSignal,
+  source: string | undefined,
+  previousValue: T | undefined,
+}
+
+export type ValidationRule<T> = (value: T, name: string, meta: ValidationRuleMeta<T>) => MaybePromise<boolean | string | void>
 
 type RulesArg<T> = MaybeRef<MaybeArray<ValidationRule<T>>>
 
@@ -45,23 +59,35 @@ export function useValidation<T>(
     throw new Error('Invalid useValidation arguments')
   }
 
-  const valueRef = ref(value)
+  const valueRef = ref(value) as Ref<T>
   const nameRef = ref(nameOrRules)
   const rulesRef = computed(() => asArray(unref(maybeRules)))
+  const previousValueRef = ref() as Ref<T>
 
   const error = ref<string>('')
   const valid = computed(() => error.value === '')
   const invalid = computed(() => !valid.value)
   const pending = ref(false)
   const validated = ref(false)
+  const executor = new ValidationRuleExecutor<T>()
 
-  const validate = async (): Promise<boolean> => {
+  const validate = async ({ source }: ValidateMethodOptions): Promise<boolean> => {
     executor.abort()
 
     pending.value = true
 
     try {
-      error.value = await executor.validate(valueRef.value as T, nameRef.value, rulesRef.value)
+      const result = await executor.validate({
+        source,
+        value: valueRef.value,
+        name: nameRef.value,
+        rules: rulesRef.value,
+        previousValue: previousValueRef.value,
+      })
+
+      if (result !== undefined) {
+        error.value = result
+      }
     } catch (error) {
       if (!(error instanceof ValidationAbortedError)) {
         console.warn('There was an error during validation')
@@ -94,10 +120,6 @@ export function useValidation<T>(
   }
 
   let mounted = false
-  const executor = new ValidationRuleExecutor<T>()
-  const observer = injectFromSelfOrAncestor(VALIDATION_OBSERVER_INJECTION_KEY)
-
-  let unregister: ValidationObserverUnregister | undefined
 
   watch(valueRef, (newValue, oldValue) => {
     if (!mounted) {
@@ -108,8 +130,14 @@ export function useValidation<T>(
       return
     }
 
-    validate()
+    previousValueRef.value = oldValue
+
+    validate({ source: 'validation' })
   }, { deep: true })
+
+  const observer = injectFromSelfOrAncestor(VALIDATION_OBSERVER_INJECTION_KEY)
+
+  let unregister: ValidationObserverUnregister | undefined
 
   onMounted(() => {
     unregister = observer?.register(validation)

--- a/src/useValidation/useValidation.ts
+++ b/src/useValidation/useValidation.ts
@@ -27,15 +27,13 @@ export type UseValidation = ToRefs<UseValidationState> & {
   state: UseValidationState,
 }
 
-export type ValidationRuleSource = 'validation' | 'observer'
-
-export type ValidationRuleMeta<T> = {
+export type ValidationRuleContext<T> = {
   signal: AbortSignal,
   source: string | undefined,
   previousValue: T | undefined,
 }
 
-export type ValidationRule<T> = (value: T, name: string, meta: ValidationRuleMeta<T>) => MaybePromise<boolean | string | void>
+export type ValidationRule<T> = (value: T, name: string, meta: ValidationRuleContext<T>) => MaybePromise<boolean | string | void>
 
 type RulesArg<T> = MaybeRef<MaybeArray<ValidationRule<T>>>
 

--- a/src/useValidationObserver/useValidationObserver.ts
+++ b/src/useValidationObserver/useValidationObserver.ts
@@ -39,7 +39,9 @@ export function useValidationObserver(): UseValidationObserver {
 
   const validate = (): Promise<boolean> => {
     const keys = Reflect.ownKeys(validations) as symbol[]
-    const promises = keys.map(key => validations[key].validate())
+    const promises = keys.map(key => validations[key].validate({
+      source: 'observer',
+    }))
 
     return Promise.all(promises).then(results => results.every(valid => valid))
   }


### PR DESCRIPTION
# Description
Convert the third argument of a ValidationRule from a single `signal` to a context argument that exposes additional information about the context of the validation. 

```typescript
export type ValidationRuleContext<T> = {
  signal: AbortSignal,
  source: string | undefined,
  previousValue: T | undefined,
}
```

This allows rules to be more dynamic based on what triggered the validation. 

Also added `void` to the return type for a `ValidationRule`. If a rule returns void its a no op. Meaning it will remain in whatever state it was previously. 