### PR TITLE
Bugfix: Update to query param compositions to allow explicit array params

### DIFF
--- a/src/useRouteQueryParam/formats/RouteParam.ts
+++ b/src/useRouteQueryParam/formats/RouteParam.ts
@@ -8,6 +8,7 @@ const IS_ROUTE_PARAM_SYMBOL: unique symbol = Symbol()
 export type RouteParamClassArgs<T> = {
   key: string,
   defaultValue: T | T[],
+  multiple: boolean,
 }
 
 // adding any here so RouteParamClass can be used without passing a generic
@@ -26,14 +27,13 @@ export abstract class RouteParam<T> {
 
   protected key: string
   protected defaultValue: T | T[] | undefined
+  protected multiple: boolean
 
-  private get multiple(): boolean {
-    return Array.isArray(this.defaultValue)
-  }
-
-  public constructor({ key, defaultValue }: RouteParamClassArgs<T>) {
+  public constructor({ key, defaultValue, multiple }: RouteParamClassArgs<T>) {
     this.key = key
     this.defaultValue = defaultValue
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    this.multiple = multiple ?? Array.isArray(defaultValue)
   }
 
   public get(routeQuery: UseRouteQuery): T | T[] | undefined {

--- a/src/useRouteQueryParam/useRouteQueryParam.ts
+++ b/src/useRouteQueryParam/useRouteQueryParam.ts
@@ -5,9 +5,12 @@ import { MaybeArray } from '@/types/maybe'
 import { useRouteQuery } from '@/useRouteQuery/useRouteQuery'
 import { isRouteParamClass, RouteParamClass } from '@/useRouteQueryParam/formats/RouteParam'
 import { StringRouteParam } from '@/useRouteQueryParam/formats/StringRouteParam'
+import { asArray } from '@/utilities/arrays'
 
-function isDefaultValue<T>(value: T | RouteParamClass): value is T {
-  return !isRouteParamClass(value)
+function isDefaultValue<T>(value: T | RouteParamClass | [RouteParamClass]): value is T {
+  const [first] = asArray(value)
+
+  return !isRouteParamClass(first)
 }
 
 export function useRouteQueryParam(key: string): Ref<string | undefined>
@@ -17,12 +20,15 @@ export function useRouteQueryParam(key: string, defaultValue: string[]): Ref<str
 export function useRouteQueryParam(key: string, defaultValue: MaybeArray<string>): Ref<MaybeArray<string>>
 export function useRouteQueryParam(key: string, defaultValue: MaybeArray<string> | undefined): Ref<MaybeArray<string> | undefined>
 export function useRouteQueryParam<T>(key: string, formatter: RouteParamClass<T>): Ref<T | undefined>
+export function useRouteQueryParam<T>(key: string, formatter: [RouteParamClass<T>]): Ref<T[] | undefined>
 export function useRouteQueryParam<T>(key: string, formatter: RouteParamClass<T>, defaultValue: NoInfer<T>): Ref<T>
 export function useRouteQueryParam<T>(key: string, formatter: RouteParamClass<T>, defaultValue: NoInfer<T> | undefined): Ref<T | undefined>
 export function useRouteQueryParam<T>(key: string, formatter: RouteParamClass<T>, defaultValue: NoInfer<T>[]): Ref<T[]>
 export function useRouteQueryParam<T>(key: string, formatter: RouteParamClass<T>, defaultValue: MaybeArray<T>): Ref<MaybeArray<T>>
 export function useRouteQueryParam<T>(key: string, formatter: RouteParamClass<T>, defaultValue: MaybeArray<T> | undefined): Ref<MaybeArray<T> | undefined>
-export function useRouteQueryParam(key: string, formatterOrDefaultValue?: RouteParamClass | MaybeArray<string> | undefined, maybeDefaultValue?: MaybeArray | undefined): Ref {
+export function useRouteQueryParam<T>(key: string, formatter: [RouteParamClass<T>], defaultValue: T[]): Ref<T[]>
+export function useRouteQueryParam<T>(key: string, formatter: [RouteParamClass<T>], defaultValue: T[] | undefined): Ref<[] | undefined>
+export function useRouteQueryParam(key: string, formatterOrDefaultValue?: RouteParamClass | [RouteParamClass] | MaybeArray<string> | undefined, maybeDefaultValue?: MaybeArray | undefined): Ref {
 
   const isStringParamWithDefaultValue = isDefaultValue(formatterOrDefaultValue)
 
@@ -31,9 +37,10 @@ export function useRouteQueryParam(key: string, formatterOrDefaultValue?: RouteP
   }
 
   const query = useRouteQuery()
-  const formatter = formatterOrDefaultValue
+  const multiple = Array.isArray(formatterOrDefaultValue)
+  const [formatter] = asArray(formatterOrDefaultValue)
   const defaultValue = maybeDefaultValue
-  const format = new formatter({ key, defaultValue })
+  const format = new formatter({ key, defaultValue, multiple })
 
   return computed({
     get() {

--- a/src/useRouteQueryParams/useRouteQueryParams.ts
+++ b/src/useRouteQueryParams/useRouteQueryParams.ts
@@ -1,14 +1,18 @@
 import { Ref } from 'vue'
-import { NoInfer, NonArray } from '@/types/generics'
+import { NoInfer } from '@/types/generics'
 import { isRouteParamClass, RouteParamClass } from '@/useRouteQueryParam/formats'
 import { useRouteQueryParam } from '@/useRouteQueryParam/useRouteQueryParam'
 
 type AnyRecord = Record<string, unknown>
 
 export type RouteQueryParamsSchema<T extends AnyRecord> = {
-  [P in keyof T]-?: NonNullable<T[P]> extends AnyRecord
+  [P in keyof Required<T>]: NonNullable<T[P]> extends AnyRecord
     ? RouteQueryParamsSchema<NonNullable<T[P]>>
-    : RouteParamClass<NonNullable<NonArray<T[P]>>>
+    : T[P] extends infer V | undefined
+      ? V extends (infer V)[]
+        ? [RouteParamClass<V>]
+        : RouteParamClass<V>
+      : never
 }
 
 export type RouteQueryParams<T extends AnyRecord> = {


### PR DESCRIPTION
Updates the `useRouteQueryParam` and `useRouteQueryParams` compositions to allow for explicitly setting the schema value as an array. 

This is technically a breaking change. But labeling this a bugfix since the previous implementation did not allow for `string[] | undefined` params without a default value of `[]`. 