### PR TITLE
BugFix: Fix params schema type discriminating to much

### DIFF
--- a/src/useRouteQueryParams/useRouteQueryParams.ts
+++ b/src/useRouteQueryParams/useRouteQueryParams.ts
@@ -8,11 +8,9 @@ type AnyRecord = Record<string, unknown>
 export type RouteQueryParamsSchema<T extends AnyRecord> = {
   [P in keyof Required<T>]: NonNullable<T[P]> extends AnyRecord
     ? RouteQueryParamsSchema<NonNullable<T[P]>>
-    : T[P] extends infer V | undefined
-      ? V extends (infer V)[]
-        ? [RouteParamClass<V>]
-        : RouteParamClass<V>
-      : never
+    : T[P] extends (infer V)[] | undefined
+      ? [RouteParamClass<V>]
+      : RouteParamClass<Exclude<T[P], undefined>>
 }
 
 export type RouteQueryParams<T extends AnyRecord> = {


### PR DESCRIPTION
# Description
It was discriminating things like `boolean` into `RouteParamClass<true> | RouteParamClass<false>` which breaks everything. Combined the check that removed undefined values with other conditions which fixes the issues. 