### PR TITLE
Enhancement: useRouteQueryParam reactivity to aggressive

### DIFF
--- a/src/useRouteQueryParam/useRouteQueryParam.ts
+++ b/src/useRouteQueryParam/useRouteQueryParam.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/unified-signatures */
-import { computed, Ref } from 'vue'
+import { computed, ref, Ref, watch } from 'vue'
 import { NoInfer } from '@/types/generics'
 import { MaybeArray } from '@/types/maybe'
 import { useRouteQuery } from '@/useRouteQuery/useRouteQuery'
@@ -42,8 +42,7 @@ export function useRouteQueryParam(key: string, formatterOrDefaultValue?: RouteP
   const [formatter] = asArray(formatterOrDefaultValue)
   const defaultValue = maybeDefaultValue
   const format = new formatter({ key, defaultValue, multiple })
-
-  return computed({
+  const param = computed({
     get() {
       return format.get(query)
     },
@@ -52,4 +51,19 @@ export function useRouteQueryParam(key: string, formatterOrDefaultValue?: RouteP
     },
   })
 
+  const response = ref(param.value)
+
+  watch(response, value => {
+    if (value !== param.value) {
+      param.value = value
+    }
+  })
+
+  watch(param, param => {
+    if (param !== response.value) {
+      response.value = param
+    }
+  })
+
+  return response
 }

--- a/src/useRouteQueryParam/useRouteQueryParam.ts
+++ b/src/useRouteQueryParam/useRouteQueryParam.ts
@@ -6,6 +6,7 @@ import { useRouteQuery } from '@/useRouteQuery/useRouteQuery'
 import { isRouteParamClass, RouteParamClass } from '@/useRouteQueryParam/formats/RouteParam'
 import { StringRouteParam } from '@/useRouteQueryParam/formats/StringRouteParam'
 import { asArray } from '@/utilities/arrays'
+import { isSame } from '@/utilities/isSame'
 
 function isDefaultValue<T>(value: T | RouteParamClass | [RouteParamClass]): value is T {
   const [first] = asArray(value)
@@ -54,13 +55,13 @@ export function useRouteQueryParam(key: string, formatterOrDefaultValue?: RouteP
   const response = ref(param.value)
 
   watch(response, value => {
-    if (value !== param.value) {
+    if (!isSame(value, param.value)) {
       param.value = value
     }
   })
 
   watch(param, param => {
-    if (param !== response.value) {
+    if (!isSame(param, response.value)) {
       response.value = param
     }
   })


### PR DESCRIPTION
# Description
Using a get/set based off of the route query means a param's reactivity effects are triggered whenever the route query is changed even if that specific param's value didn't change. Returning a plain ref and using watchers to sync it with the route prevents that from happening. 