### PR TITLE
Enhancement: Sync value to input ref if debounced ref is set in useDebouncedRef

### DIFF
--- a/src/useDebouncedRef/useDebouncedRef.spec.ts
+++ b/src/useDebouncedRef/useDebouncedRef.spec.ts
@@ -21,6 +21,8 @@ describe('useDebouncedRef', () => {
     const output = useDebouncedRef(input, 100)
     input.value = 2
 
+    expect(output.value).toBe(1)
+
     await vi.runAllTimersAsync()
 
     expect(output.value).toBe(2)

--- a/src/useDebouncedRef/useDebouncedRef.spec.ts
+++ b/src/useDebouncedRef/useDebouncedRef.spec.ts
@@ -1,0 +1,38 @@
+import { afterEach, vi, expect, describe, it } from 'vitest'
+import { ref } from 'vue'
+import { useDebouncedRef } from '@/useDebouncedRef/useDebouncedRef'
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useDebouncedRef', () => {
+
+  it('it syncs the initial value', () => {
+    const input = ref(1)
+    const output = useDebouncedRef(input, 100)
+
+    expect(output.value).toBe(1)
+  })
+
+  it('it debounces updates to the value', async () => {
+    vi.useFakeTimers()
+    const input = ref(1)
+    const output = useDebouncedRef(input, 100)
+    input.value = 2
+
+    await vi.runAllTimersAsync()
+
+    expect(output.value).toBe(2)
+  })
+
+  it('it syncs the debounced value back to the input', async () => {
+    vi.useFakeTimers()
+    const input = ref(1)
+    const output = useDebouncedRef(input, 100)
+    output.value = 2
+
+    expect(input.value).toBe(2)
+  })
+
+})

--- a/src/useDebouncedRef/useDebouncedRef.spec.ts
+++ b/src/useDebouncedRef/useDebouncedRef.spec.ts
@@ -26,7 +26,7 @@ describe('useDebouncedRef', () => {
     expect(output.value).toBe(2)
   })
 
-  it('it syncs the debounced value back to the input', async () => {
+  it('it syncs the debounced value back to the input', () => {
     vi.useFakeTimers()
     const input = ref(1)
     const output = useDebouncedRef(input, 100)

--- a/src/useDebouncedRef/useDebouncedRef.ts
+++ b/src/useDebouncedRef/useDebouncedRef.ts
@@ -4,7 +4,11 @@ import { ref, Ref, watch, watchEffect } from 'vue'
 export function useDebouncedRef<T>(input: Ref<T>, wait: Ref<number> | number): Ref<T> {
   const waitRef = ref(wait)
   const copy = ref(input.value) as Ref<T>
-  const update = debounce((value: T) => copy.value = value, waitRef.value)
+  const update = debounce((value: T) => {
+    if (value !== copy.value) {
+      copy.value = value
+    }
+  }, waitRef.value)
 
   watchEffect(() => update(input.value))
 

--- a/src/useDebouncedRef/useDebouncedRef.ts
+++ b/src/useDebouncedRef/useDebouncedRef.ts
@@ -9,7 +9,9 @@ export function useDebouncedRef<T>(input: Ref<T>, wait: Ref<number> | number): R
   watchEffect(() => update(input.value))
 
   watch(copy, value => {
-    input.value = value
+    if (value !== input.value) {
+      input.value = value
+    }
   }, { flush: 'sync' })
 
   return copy

--- a/src/useDebouncedRef/useDebouncedRef.ts
+++ b/src/useDebouncedRef/useDebouncedRef.ts
@@ -1,12 +1,16 @@
 import debounce from 'lodash.debounce'
-import { ref, Ref, watchEffect } from 'vue'
+import { ref, Ref, watch, watchEffect } from 'vue'
 
 export function useDebouncedRef<T>(input: Ref<T>, wait: Ref<number> | number): Ref<T> {
   const waitRef = ref(wait)
-  const copy = ref<T>(input.value) as Ref<T>
+  const copy = ref(input.value) as Ref<T>
   const update = debounce((value: T) => copy.value = value, waitRef.value)
 
   watchEffect(() => update(input.value))
+
+  watch(copy, value => {
+    input.value = value
+  }, { flush: 'sync' })
 
   return copy
 }


### PR DESCRIPTION
# Description
`useDebouncedRef` returns `Ref<T>` but if you set the value of that ref nothing happens. The intent of this composition is that the refs are the same but that there is a reactivity delay for the debounced version. This update will sync the value from the debounced ref back to the input ref (immediately). 

I also added some unit tests for this composition