### PR TITLE
Enhancement: `useSubscription` reactive options [RFC]

### DIFF
--- a/src/useSubscription/types/subscription.ts
+++ b/src/useSubscription/types/subscription.ts
@@ -1,10 +1,11 @@
+import { MaybeRef } from '@/types/maybe'
 import Manager from '@/useSubscription/models/manager'
 import Subscription from '@/useSubscription/models/subscription'
 import { Action, ActionArguments, ActionParamsRequired, ActionResponse } from '@/useSubscription/types/action'
 
 export type SubscribeArguments<T extends Action> = ActionParamsRequired<T> extends never[]
-  ? [action: T, args?: ActionArguments<T>, options?: SubscriptionOptions]
-  : [action: T, args: ActionArguments<T>, options?: SubscriptionOptions]
+  ? [action: T, args?: ActionArguments<T>, options?: MaybeRef<SubscriptionOptions>]
+  : [action: T, args: ActionArguments<T>, options?: MaybeRef<SubscriptionOptions>]
 
 export type SubscriptionOptions = {
   interval?: number,

--- a/src/useSubscription/useSubscription.spec.ts
+++ b/src/useSubscription/useSubscription.spec.ts
@@ -502,4 +502,31 @@ describe('subscribe', () => {
     expect(action).toBeCalledTimes(1)
   })
 
+  it('is retains subscription when reactive options change', async () => {
+    vi.useFakeTimers()
+
+    const action = vi.fn()
+
+    const interval = ref(1000)
+    const options = computed(() => {
+      return {
+        interval: interval.value,
+      }
+    })
+
+    uniqueSubscribe(action, [], options)
+
+    expect(action).toBeCalledTimes(1)
+
+    interval.value = Infinity
+
+    expect(action).toBeCalledTimes(1)
+
+    interval.value = 1000
+
+    vi.advanceTimersByTime(1000)
+
+    expect(action).toBeCalledTimes(2)
+  })
+
 })

--- a/src/useSubscription/useSubscription.ts
+++ b/src/useSubscription/useSubscription.ts
@@ -1,4 +1,4 @@
-import { getCurrentInstance, onUnmounted, reactive, unref } from 'vue'
+import { getCurrentInstance, onUnmounted, reactive, ref, unref } from 'vue'
 import Manager from '@/useSubscription/models/manager'
 import { Action, ActionArguments } from '@/useSubscription/types/action'
 import { SubscribeArguments, UseSubscription } from '@/useSubscription/types/subscription'
@@ -34,22 +34,17 @@ export function useSubscription<T extends Action>(...[action, args, optionsArg =
   }, { deep: true })
 
   const unwatchOptions = uniqueValueWatcher(getValidWatchSource(optionsArg), () => {
-
     if (!subscriptionResponse.isSubscribed()) {
       unwatchOptions!()
       return
     }
 
     const options = unref(optionsArg)
+    const manager = options.manager ?? defaultManager
     const newSubscription = manager.subscribe(action, argsWithDefault, options)
-
-    newSubscription.response.value ??= subscriptionResponse.response
-    newSubscription.executed.value = newSubscription.executed.value || subscriptionResponse.executed
-
     subscriptionResponse.unsubscribe()
 
     Object.assign(subscriptionResponse, mapSubscription(newSubscription))
-
   }, { deep: true })
 
   if (getCurrentInstance()) {

--- a/src/useSubscription/useSubscription.ts
+++ b/src/useSubscription/useSubscription.ts
@@ -8,8 +8,8 @@ import { uniqueValueWatcher } from '@/utilities/uniqueValueWatcher'
 
 const defaultManager = new Manager()
 
-export function useSubscription<T extends Action>(...[action, args, optionArgs = {}]: SubscribeArguments<T>): UseSubscription<T> {
-  const options = optionArgs ? unref(optionArgs) : {}
+export function useSubscription<T extends Action>(...[action, args, optionsArg = {}]: SubscribeArguments<T>): UseSubscription<T> {
+  const options = unref(optionsArg) ?? {}
   const manager = options.manager ?? defaultManager
   const argsWithDefault = args ?? [] as unknown as ActionArguments<T>
   const originalSubscription = manager.subscribe(action, argsWithDefault, options)
@@ -33,15 +33,14 @@ export function useSubscription<T extends Action>(...[action, args, optionArgs =
     Object.assign(subscriptionResponse, mapSubscription(newSubscription))
   }, { deep: true })
 
-  const unwatchOptions = uniqueValueWatcher(getValidWatchSource(optionArgs), () => {
+  const unwatchOptions = uniqueValueWatcher(getValidWatchSource(optionsArg), () => {
 
     if (!subscriptionResponse.isSubscribed()) {
       unwatchOptions!()
       return
     }
 
-    const options = unref(optionArgs)
-
+    const options = unref(optionsArg)
     const newSubscription = manager.subscribe(action, argsWithDefault, options)
 
     newSubscription.response.value ??= subscriptionResponse.response

--- a/src/useSubscription/useSubscription.ts
+++ b/src/useSubscription/useSubscription.ts
@@ -9,7 +9,7 @@ import { uniqueValueWatcher } from '@/utilities/uniqueValueWatcher'
 const defaultManager = new Manager()
 
 export function useSubscription<T extends Action>(...[action, args, optionsArg = {}]: SubscribeArguments<T>): UseSubscription<T> {
-  const options = unref(optionsArg) ?? {}
+  const options = unref(optionsArg)
   const manager = options.manager ?? defaultManager
   const argsWithDefault = args ?? [] as unknown as ActionArguments<T>
   const originalSubscription = manager.subscribe(action, argsWithDefault, options)

--- a/src/useSubscription/useSubscriptionWithDependencies.ts
+++ b/src/useSubscription/useSubscriptionWithDependencies.ts
@@ -1,13 +1,14 @@
 import { reactive, ref, Ref, toRaw, watch } from 'vue'
 import { Action, SubscriptionOptions, UseSubscription, ActionArguments, MappedSubscription } from '@/useSubscription/types'
 import { useSubscription } from '@/useSubscription/useSubscription'
+import { MaybeRef } from '@/types/maybe'
 
 const voidAction = (): undefined => undefined
 
 type UseSubscriptionWithDependencies<T extends Action> = [
   action: T,
   args: Ref<Parameters<T> | null>,
-  options?: SubscriptionOptions
+  options?: MaybeRef<SubscriptionOptions>
 ]
 
 // returns a void subscription with executed overridden to be false

--- a/src/utilities/tests.ts
+++ b/src/utilities/tests.ts
@@ -1,4 +1,4 @@
-import { isRef } from 'vue'
+import { computed, isRef, unref } from 'vue'
 import { useSubscription } from '@/useSubscription'
 import Manager from '@/useSubscription/models/manager'
 import { Action } from '@/useSubscription/types/action'
@@ -8,12 +8,15 @@ export function timeout(ms = 0): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
-export function uniqueSubscribe<T extends Action>(...[action, args, options = {}]: SubscribeArguments<T>): UseSubscription<T> {
-  if (isRef(options)) {
-    options.value.manager = new Manager()
-  } else {
-    options.manager = new Manager()
-  }
+export function uniqueSubscribe<T extends Action>(...[action, args, optionsArg = {}]: SubscribeArguments<T>): UseSubscription<T> {
+  const options = computed(() => {
+    const options = unref(optionsArg)
+
+    return {
+      ...options,
+      manager: new Manager(),
+    }
+  })
 
   return useSubscription(action, args, options)
 }

--- a/src/utilities/tests.ts
+++ b/src/utilities/tests.ts
@@ -10,7 +10,7 @@ export function timeout(ms = 0): Promise<void> {
 
 export function uniqueSubscribe<T extends Action>(...[action, args, options = {}]: SubscribeArguments<T>): UseSubscription<T> {
   if (isRef(options)) {
-    options.value.manager = options.value.manager
+    options.value.manager = new Manager()
   } else {
     options.manager = new Manager()
   }

--- a/src/utilities/tests.ts
+++ b/src/utilities/tests.ts
@@ -1,4 +1,4 @@
-import { computed, isRef, unref } from 'vue'
+import { computed, unref } from 'vue'
 import { useSubscription } from '@/useSubscription'
 import Manager from '@/useSubscription/models/manager'
 import { Action } from '@/useSubscription/types/action'

--- a/src/utilities/tests.ts
+++ b/src/utilities/tests.ts
@@ -2,16 +2,18 @@ import { useSubscription } from '@/useSubscription'
 import Manager from '@/useSubscription/models/manager'
 import { Action } from '@/useSubscription/types/action'
 import { SubscribeArguments, UseSubscription } from '@/useSubscription/types/subscription'
+import { isRef } from 'vue'
 
 export function timeout(ms = 0): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
 export function uniqueSubscribe<T extends Action>(...[action, args, options = {}]: SubscribeArguments<T>): UseSubscription<T> {
-  const optionsWithManager = {
-    ...options,
-    manager: new Manager(),
+  if (isRef(options)) {
+    options.value.manager = options.value.manager
+  } else {
+    options.manager = new Manager()
   }
 
-  return useSubscription(action, args, optionsWithManager)
+  return useSubscription(action, args, options)
 }

--- a/src/utilities/tests.ts
+++ b/src/utilities/tests.ts
@@ -1,8 +1,8 @@
+import { isRef } from 'vue'
 import { useSubscription } from '@/useSubscription'
 import Manager from '@/useSubscription/models/manager'
 import { Action } from '@/useSubscription/types/action'
 import { SubscribeArguments, UseSubscription } from '@/useSubscription/types/subscription'
-import { isRef } from 'vue'
 
 export function timeout(ms = 0): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))


### PR DESCRIPTION
This PR slightly changes the behavior of the `useSubscription` composition, which previously took a static `options` argument, to instead take either a static `options` argument or a `Ref`. The composition now reacts to options changes and modifies the resulting subscription accordingly. 

Example:
```ts
const num = ref(0)
const interval = ref(1000)

function incNum(): void {
  num.value += 1
}

function toggleInterval(): void {
  interval.value = interval.value === Infinity ? 1000 : Infinity
}

const subscriptionOptions = computed<SubscriptionOptions>(() => {
  return {
    interval: interval.value,
  }
})

useSubscription(incNum, [], subscriptionOptions)
```

In the above example, when `interval` is set to `Infinity`, `num` will stop incrementing. When `interval` is set to `1000` again, it will appropriately resume incrementing