### PR TITLE
Enhancement: Update useVisibilityObserver to use reactive options

### DIFF
--- a/src/useIntersectionObserver/useIntersectionObserver.ts
+++ b/src/useIntersectionObserver/useIntersectionObserver.ts
@@ -95,7 +95,6 @@ export function useIntersectionObserver(callback: UseIntersectionObserverCallbac
   })
 
   watch(optionsRef, () => {
-    console.log('here')
     createObserver()
   })
 


### PR DESCRIPTION
# Description
Updates the `options` argument to be `Maybe<UseIntersectionObserverOptions>` and updates the internal logic to tear down the existing observer and create a new one when options change. It does this while keeping track of elements that are currently being observed.

Closes https://github.com/PrefectHQ/vue-compositions/issues/220