### PR TITLE
Feature: added lifecycle option to useSubscription

### DIFF
--- a/src/useSubscription/types/subscription.ts
+++ b/src/useSubscription/types/subscription.ts
@@ -10,6 +10,7 @@ export type SubscribeArguments<T extends Action> = ActionParamsRequired<T> exten
 export type SubscriptionOptions = {
   interval?: number,
   manager?: Manager,
+  lifecycle?: 'component' | 'app',
 }
 
 export type SubscriptionPromise<T extends Action> = Promise<Omit<UseSubscription<T>, 'promise'> & { response: ActionResponse<T> }>

--- a/src/useSubscription/useSubscription.spec.ts
+++ b/src/useSubscription/useSubscription.spec.ts
@@ -315,13 +315,12 @@ describe('subscribe', () => {
     expect(subscription.response).toBe(true)
   })
 
-  const unmountedOptionCases: (SubscriptionOptions | undefined)[] = [
+  test.each<SubscriptionOptions | undefined>([
     undefined,
     {},
     { interval: 3000 },
     { lifecycle: 'component' },
-  ]
-  test.each(unmountedOptionCases)('calls unsubscribe when component is unmounted with default lifecycle', (options?: SubscriptionOptions) => {
+  ])('calls unsubscribe when component is unmounted with default lifecycle', (options?: SubscriptionOptions) => {
     const action = vi.fn()
     let subscription: UseSubscription<typeof action>
 

--- a/src/useSubscription/useSubscription.ts
+++ b/src/useSubscription/useSubscription.ts
@@ -1,15 +1,16 @@
-import { getCurrentInstance, onUnmounted, reactive, ref, unref } from 'vue'
+import { getCurrentInstance, onUnmounted, reactive, unref } from 'vue'
 import Manager from '@/useSubscription/models/manager'
 import { Action, ActionArguments } from '@/useSubscription/types/action'
-import { SubscribeArguments, UseSubscription } from '@/useSubscription/types/subscription'
+import { SubscribeArguments, SubscriptionOptions, UseSubscription } from '@/useSubscription/types/subscription'
 import { mapSubscription } from '@/useSubscription/utilities/subscriptions'
 import { getValidWatchSource } from '@/utilities/getValidWatchSource'
 import { uniqueValueWatcher } from '@/utilities/uniqueValueWatcher'
 
 const defaultManager = new Manager()
+const defaultOptions: SubscriptionOptions = { lifecycle: 'component' }
 
 export function useSubscription<T extends Action>(...[action, args, optionsArg = {}]: SubscribeArguments<T>): UseSubscription<T> {
-  const options = unref(optionsArg)
+  const options = { ...defaultOptions, ...unref(optionsArg) }
   const manager = options.manager ?? defaultManager
   const argsWithDefault = args ?? [] as unknown as ActionArguments<T>
   const originalSubscription = manager.subscribe(action, argsWithDefault, options)
@@ -47,7 +48,7 @@ export function useSubscription<T extends Action>(...[action, args, optionsArg =
     Object.assign(subscriptionResponse, mapSubscription(newSubscription))
   }, { deep: true })
 
-  if (getCurrentInstance()) {
+  if (options.lifecycle === 'component' && getCurrentInstance()) {
     onUnmounted(() => {
       subscriptionResponse.unsubscribe()
       unwatchOptions()


### PR DESCRIPTION
when creating a subscription, you now have the option of passing in a `lifecycle` argument to override the default behavior to unsubscribe on component unmount. 

```ts
const livesForever = useSubscription(myCoolFunction, [], { lifecycle: 'app' })
```

even when the component that calls `useSubscription` in it's setup gets unmounted, the manager will retain the subscription and any data fetched for the life of the app.