### PR TITLE
Enhancement: Channel response reactivity

### DIFF
--- a/src/useSubscription/models/channel.ts
+++ b/src/useSubscription/models/channel.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-classes-per-file */
+import { isEqual } from 'lodash'
 import Manager from '@/useSubscription/models/manager'
 import Subscription from '@/useSubscription/models/subscription'
 import {
@@ -72,6 +73,10 @@ export default class Channel<T extends Action = Action> {
   }
 
   private set response(response: ActionResponse<T> | undefined) {
+    if (isEqual(this._response, response)) {
+      return
+    }
+
     this._response = response
 
     for (const subscription of this.subscriptions.values()) {


### PR DESCRIPTION
# Description
Each time a channel executes the action it sets the response value on the cannel itself and on each subscription to that channel. The response on a subscription is a `ref` which means assigning it triggers reactive effects. Trigger reactive effects can cascade and cause quite a bit of processing/rendering. 

This has caused issues with dependent subscriptions refreshing unnecessarily (fixed by `uniqueValueWatcher`) and computed values and component templates being re-evaluated. Technically this is correct because the ref was assigned and everything that depends on that ref should be re-evaluated. 

However this is usually not desired if the actual value of the subscription has not changed. If an action returns the same value as the previous execution, there is no need to trigger effects. 

Checking if the new action response is the same as the previous before assigning it fixes this issue. I was hesitant to introduce a deep equality check. But @znicholasbrown and I both believe the cost of this check is actually a net positive once considering all of the reactive effects that are no longer triggered. 