### PR TITLE
Enhancement: Remove nullish query param's keys

### DIFF
--- a/src/useRouteQuery/useRouteQuery.ts
+++ b/src/useRouteQuery/useRouteQuery.ts
@@ -48,7 +48,11 @@ function factory(): () => UseRouteQuery {
     }
 
     const set = (key: string, value: LocationQueryValue | LocationQueryValue[]): void => {
-      query[key] = value
+      if (value?.length === 0) {
+        remove(key)
+      } else {
+        query[key] = value
+      }
     }
 
     const get = (key: string): LocationQueryValue | LocationQueryValue[] => {


### PR DESCRIPTION
This PR slightly changes the behavior of the `useRouteQuery` composition by deleting keys from the URL whose values have been set to a nullish value. 

This is nice because empty values clutter up the URL without much added value, e.g.:
```
https://some.url/?search=&tags=foo,bar
```
vs
```
https://some.url/?tags=foo,bar
```