### PR TITLE
BugFix: `uniqueValueWatcher` utility doesn't account for dates

### DIFF
--- a/src/utilities/dates.ts
+++ b/src/utilities/dates.ts
@@ -1,0 +1,3 @@
+export function isDate(value: unknown): value is Date {
+  return value instanceof Date
+}

--- a/src/utilities/objects.ts
+++ b/src/utilities/objects.ts
@@ -1,5 +1,7 @@
+import { isDate } from '@/utilities/dates'
+
 export function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null
+  return typeof value === 'object' && value !== null && !isDate(value)
 }
 
 export type MapKeysCallback<PreviousKey extends PropertyKey, Value, NewKey extends PropertyKey> = (key: PreviousKey, value: Value) => NewKey


### PR DESCRIPTION
# Description
Because properties of type `Date` were being checked as type `Record` all dates "raw" value ended up being `{}`. Specifically excluding dates from the `isRecord` check fixes that and makes the watcher accurately pick up date changes. 