### PR TITLE
Feature: `useBoolean` composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ npm i --save @prefecthq/vue-compositions
 ```
 
 ## Compositions
+- [useBoolean](https://github.com/prefecthq/vue-compositions/tree/main/src/useBoolean)
 - [useChildrenAreWrapped](https://github.com/prefecthq/vue-compositions/tree/main/src/useChildrenAreWrapped)
 - [useComputedStyle](https://github.com/prefecthq/vue-compositions/tree/main/src/useComputedStyle)
 - [useDebouncedRef](https://github.com/prefecthq/vue-compositions/tree/main/src/useDebouncedRef)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from './useBoolean'
 export * from './useChildrenAreWrapped'
 export * from './useComputedStyle'
 export * from './useDebouncedRef'

--- a/src/useBoolean/README.md
+++ b/src/useBoolean/README.md
@@ -1,0 +1,37 @@
+# useBoolean
+The `useBoolean` is a utility composition for handling the state of a boolean ref
+
+## Example
+```typescript
+import { ref } from 'vue'
+import { useBoolean } from '@prefecthq/vue-compositions'
+
+const initialValueRef = ref(false)
+// The initial ref is optional
+const { value, setTrue, setFalse, toggle } = useBoolean(initialValueRef)
+
+value.value // false
+
+value.value = true
+value.value // true
+
+setFalse()
+value.value // false
+
+setTrue()
+value.value // true
+
+toggle()
+value.value // false
+
+toggle()
+value.value // true
+```
+
+## Arguments
+| Name         | Type                   | Default |
+|--------------|------------------------|---------|
+| valueRef     | `MaybeRef<boolean>`    | false   |
+
+## Returns
+`UseBooleanToggle`

--- a/src/useBoolean/index.ts
+++ b/src/useBoolean/index.ts
@@ -1,0 +1,1 @@
+export * from './useBoolean'

--- a/src/useBoolean/useBoolean.ts
+++ b/src/useBoolean/useBoolean.ts
@@ -1,0 +1,28 @@
+import { ref } from 'vue'
+import { MaybeRef } from '@/types/maybe'
+
+type UseBoolean = {
+  value: MaybeRef<boolean>,
+  toggle: () => void,
+  setTrue: () => void,
+  setFalse: () => void,
+}
+
+export function useBoolean(valueRef?: MaybeRef<boolean>): UseBoolean {
+  const value = ref(valueRef ?? false)
+
+  const toggle = (): void => {
+    value.value = !value.value
+  }
+
+  const setTrue = (): void => {
+    value.value = true
+  }
+
+  const setFalse = (): void => {
+    value.value = false
+  }
+
+  return { value, toggle, setTrue, setFalse }
+}
+

--- a/src/useBoolean/useBoolean.ts
+++ b/src/useBoolean/useBoolean.ts
@@ -8,6 +8,25 @@ type UseBoolean = {
   setFalse: () => void,
 }
 
+/**
+ * `useBoolean` is a utility composition for managing a boolean state.
+ * It returns an object with `value`, `toggle`, `setTrue`, and `setFalse` properties.
+ *
+ * @param {MaybeRef<boolean>} [valueRef] - Optional parameter. A Vue ref object or a boolean that holds the initial state.
+ *
+ * @returns {UseBoolean} - An object with the following properties:
+ *                        `value`: a Vue ref object that holds the current boolean state.
+ *                        `toggle`: a method to toggle the state.
+ *                        `setTrue`: a method to set the state to true.
+ *                        `setFalse`: a method to set the state to false.
+ *
+ * @example
+ * const { toggle, setTrue, setFalse, value } = useBoolean()
+ * toggle() // toggle the state
+ * setTrue() // set the state to true
+ * setFalse() // set the state to false
+ * console.log(value.value) // check the current state
+ */
 export function useBoolean(valueRef?: MaybeRef<boolean>): UseBoolean {
   const value = ref(valueRef ?? false)
 


### PR DESCRIPTION
This PR introduces a `useBoolean` composition which is a handy utility wrapper for managing the state of a `ref<boolean>`.