### PR TITLE
Enhancement: Add `interval` option to `useNow` to limit effects

### DIFF
--- a/src/useNow/useNow.ts
+++ b/src/useNow/useNow.ts
@@ -1,4 +1,5 @@
 import { ref, Ref } from 'vue'
+import { MaybeRef } from '@/types/maybe'
 import { tryOnScopeDispose } from '@/utilities/tryOnScopeDispose'
 
 export type UseNow = {
@@ -9,7 +10,7 @@ export type UseNow = {
 
 export type UseNowArgs = {
   immediate?: boolean,
-  interval?: number,
+  interval?: MaybeRef<number>,
 }
 
 export function useNow({
@@ -17,12 +18,13 @@ export function useNow({
   interval = 0,
 }: UseNowArgs = {}): UseNow {
   const response = ref(new Date())
+  const intervalRef = ref(interval)
   let id: null | number = null
 
   function update(): void {
     const now = new Date()
 
-    if (now.getTime() - response.value.getTime() > interval) {
+    if (now.getTime() - response.value.getTime() > intervalRef.value) {
       response.value = now
     }
 

--- a/src/useNow/useNow.ts
+++ b/src/useNow/useNow.ts
@@ -17,14 +17,25 @@ export function useNow({
   immediate = true,
   interval = 0,
 }: UseNowArgs = {}): UseNow {
-  const response = ref(new Date())
+  const response = ref(getNow())
   const intervalRef = ref(interval)
   let id: null | number = null
 
-  function update(): void {
-    const now = new Date()
+  function getNow(): Date {
+    if (intervalRef.value === 0) {
+      return new Date()
+    }
 
-    if (now.getTime() - response.value.getTime() > intervalRef.value) {
+    const time = new Date().getTime()
+    const nearest = Math.round(time / intervalRef.value) * intervalRef.value
+
+    return new Date(nearest)
+  }
+
+  function update(): void {
+    const now = getNow()
+
+    if (response.value.getTime() !== now.getTime()) {
       response.value = now
     }
 

--- a/src/useNow/useNow.ts
+++ b/src/useNow/useNow.ts
@@ -9,14 +9,22 @@ export type UseNow = {
 
 export type UseNowArgs = {
   immediate?: boolean,
+  interval?: number,
 }
 
-export function useNow({ immediate = true }: UseNowArgs = {}): UseNow {
-  const now = ref(new Date())
+export function useNow({
+  immediate = true,
+  interval = 0,
+}: UseNowArgs = {}): UseNow {
+  const response = ref(new Date())
   let id: null | number = null
 
   function update(): void {
-    now.value = new Date()
+    const now = new Date()
+
+    if (now.getTime() - response.value.getTime() > interval) {
+      response.value = now
+    }
 
     id = window.requestAnimationFrame(update)
   }
@@ -40,7 +48,7 @@ export function useNow({ immediate = true }: UseNowArgs = {}): UseNow {
   tryOnScopeDispose(pause)
 
   return {
-    now,
+    now: response,
     resume,
     pause,
   }


### PR DESCRIPTION
# Description
Its quite possible a use case might only need "now" up to a certain precision (every second, minute, etc). Providing an interval allows the implementation to dictate how often the value is updated and how often effects are triggered. 