### PR TITLE
Enhancement: Run subscription actions in an effect scope that is disposed when a channel is deleted

### DIFF
--- a/src/useSubscription/useSubscription.spec.ts
+++ b/src/useSubscription/useSubscription.spec.ts
@@ -571,4 +571,24 @@ describe('subscribe', () => {
     expect(spy).toBeCalledTimes(1)
   })
 
+  it('changing args unsubscribes nested subscriptions automatically', async () => {
+    const number = ref(0)
+    const manager = new Manager()
+    const action = vi.fn()
+    let childSubscription: UseSubscription<typeof action>
+
+    useSubscription((number: number): number => {
+      childSubscription = useSubscription(action)
+      return number
+    }, [number], { manager })
+
+    const spy = vi.spyOn(childSubscription!, 'unsubscribe')
+
+    number.value++
+
+    await timeout()
+
+    expect(spy).toBeCalledTimes(1)
+  })
+
 })

--- a/src/useSubscription/useSubscription.spec.ts
+++ b/src/useSubscription/useSubscription.spec.ts
@@ -528,7 +528,7 @@ describe('subscribe', () => {
     expect(action).toBeCalledTimes(1)
   })
 
-  it('is retains subscription when reactive options change', async () => {
+  it('is retains subscription when reactive options change', () => {
     vi.useFakeTimers()
 
     const action = vi.fn()
@@ -553,6 +553,22 @@ describe('subscribe', () => {
     vi.advanceTimersByTime(1000)
 
     expect(action).toBeCalledTimes(2)
+  })
+
+  it('unsubscribes nested subscriptions automatically', () => {
+    const manager = new Manager()
+    const action = vi.fn()
+    let childSubscription: UseSubscription<typeof action>
+
+    const subscription = useSubscription((): void => {
+      childSubscription = useSubscription(action)
+    }, [], { manager })
+
+    const spy = vi.spyOn(childSubscription!, 'unsubscribe')
+
+    subscription.unsubscribe()
+
+    expect(spy).toBeCalledTimes(1)
   })
 
 })

--- a/src/useSubscription/useSubscription.ts
+++ b/src/useSubscription/useSubscription.ts
@@ -1,9 +1,10 @@
-import { getCurrentScope, onScopeDispose, reactive, unref } from 'vue'
+import { reactive, unref } from 'vue'
 import Manager from '@/useSubscription/models/manager'
 import { Action, ActionArguments } from '@/useSubscription/types/action'
 import { SubscribeArguments, UseSubscription } from '@/useSubscription/types/subscription'
 import { mapSubscription } from '@/useSubscription/utilities/subscriptions'
 import { getValidWatchSource } from '@/utilities/getValidWatchSource'
+import { tryOnScopeDispose } from '@/utilities/tryOnScopeDispose'
 import { uniqueValueWatcher } from '@/utilities/uniqueValueWatcher'
 
 const defaultManager = new Manager()
@@ -47,17 +48,15 @@ export function useSubscription<T extends Action>(...[action, args, optionsArg =
     Object.assign(subscriptionResponse, mapSubscription(newSubscription))
   }, { deep: true })
 
-  if (getCurrentScope()) {
-    onScopeDispose(() => {
-      const { lifecycle = 'component' } = unref(optionsArg)
+  tryOnScopeDispose(() => {
+    const { lifecycle = 'component' } = unref(optionsArg)
 
-      if (lifecycle === 'component') {
-        subscriptionResponse.unsubscribe()
-        unwatchOptions()
-        unwatch()
-      }
-    })
-  }
+    if (lifecycle === 'component') {
+      subscriptionResponse.unsubscribe()
+      unwatchOptions()
+      unwatch()
+    }
+  })
 
   return subscriptionResponse
 }

--- a/src/useSubscription/useSubscription.ts
+++ b/src/useSubscription/useSubscription.ts
@@ -1,4 +1,4 @@
-import { getCurrentInstance, onUnmounted, reactive, unref } from 'vue'
+import { getCurrentScope, onScopeDispose, reactive, unref } from 'vue'
 import Manager from '@/useSubscription/models/manager'
 import { Action, ActionArguments } from '@/useSubscription/types/action'
 import { SubscribeArguments, UseSubscription } from '@/useSubscription/types/subscription'
@@ -47,8 +47,8 @@ export function useSubscription<T extends Action>(...[action, args, optionsArg =
     Object.assign(subscriptionResponse, mapSubscription(newSubscription))
   }, { deep: true })
 
-  if (getCurrentInstance()) {
-    onUnmounted(() => {
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
       const { lifecycle = 'component' } = unref(optionsArg)
 
       if (lifecycle === 'component') {


### PR DESCRIPTION
# Description
Two minor changes
- Use `getCurrentScope` and `onScopeDispose` rather than `getCurrentInstance` and `onUnmounted` in the `useSubscription` composition. This allows subscriptions to automatically unsubscribe when run in any scope and not just components
- Adds an effect scope to `Channel` that is used when running the action. The scope is disposed of when the channel is deleted. 

## Motivation
Automatically wrapping actions in an effect scope means actions can create reactive effects that are automatically disposed. Nested subscriptions will automatically unsubscribe when the parent action is unsubscribed. And any other composition or utility can automatically disposes. 