### PR TITLE
Enhancement: Create a new scope for each execution when refreshing subscriptions

### DIFF
--- a/src/useSubscription/models/channel.ts
+++ b/src/useSubscription/models/channel.ts
@@ -194,11 +194,9 @@ export default class Channel<T extends Action = Action> {
   }
 
   public refresh(): Promise<void> {
-    const previousScope = this.scope
+    this.scope.stop()
     this.scope = effectScope()
     const response = this.execute()
-
-    previousScope.stop()
 
     return response
   }

--- a/src/useSubscription/models/channel.ts
+++ b/src/useSubscription/models/channel.ts
@@ -44,7 +44,7 @@ export default class Channel<T extends Action = Action> {
   private readonly action: T
   private readonly args: ActionArguments<T>
   private readonly subscriptions: Map<number, Subscription<T>> = new Map()
-  private readonly scope = effectScope()
+  private scope = effectScope()
   private timer: ReturnType<typeof setInterval> | null = null
   private lastExecution: number = 0
   private _loading: boolean = false
@@ -193,6 +193,16 @@ export default class Channel<T extends Action = Action> {
     }
   }
 
+  public refresh(): Promise<void> {
+    const previousScope = this.scope
+    this.scope = effectScope()
+    const response = this.execute()
+
+    previousScope.stop()
+
+    return response
+  }
+
   public isSubscribed(id: number): boolean {
     return this.subscriptions.has(id)
   }
@@ -217,6 +227,6 @@ export default class Channel<T extends Action = Action> {
     const sinceLastRun = Date.now() - this.lastExecution
     const timeTillNextExecution = this.interval - sinceLastRun
 
-    this.timer = setTimeout(() => this.execute(), timeTillNextExecution)
+    this.timer = setTimeout(() => this.refresh(), timeTillNextExecution)
   }
 }

--- a/src/useSubscription/models/subscription.ts
+++ b/src/useSubscription/models/subscription.ts
@@ -36,7 +36,7 @@ export default class Subscription<T extends Action> {
   }
 
   public async refresh(): Promise<void> {
-    await this.channel.execute()
+    await this.channel.refresh()
   }
 
   public unsubscribe(): void {

--- a/src/useSubscription/useSubscription.spec.ts
+++ b/src/useSubscription/useSubscription.spec.ts
@@ -571,14 +571,14 @@ describe('subscribe', () => {
     expect(spy).toBeCalledTimes(1)
   })
 
-  it('changing args unsubscribes nested subscriptions automatically', async () => {
+  it('unsubscribes nested subscriptions when changing args', async () => {
     const number = ref(0)
     const manager = new Manager()
     const action = vi.fn()
     let childSubscription: UseSubscription<typeof action>
 
     useSubscription((number: number): number => {
-      childSubscription = useSubscription(action)
+      childSubscription = useSubscription(action, [], { manager })
       return number
     }, [number], { manager })
 
@@ -589,6 +589,22 @@ describe('subscribe', () => {
     await timeout()
 
     expect(spy).toBeCalledTimes(1)
+  })
+
+  it('it refreshes nested subscriptions when calling refresh', async () => {
+    const action = vi.fn()
+    const manager = new Manager()
+    const subscription = useSubscription((): void => {
+      useSubscription(action, [], { manager })
+    }, [], { manager })
+
+    await timeout()
+
+    subscription.refresh()
+
+    await timeout()
+
+    expect(action).toBeCalledTimes(2)
   })
 
 })


### PR DESCRIPTION
# Description
When refreshing a subscription (either manually or via an interval) the effect scope of the channel should be disposed. This makes sure any reactive effects are disposed of properly and ensures a refresh executes nested subscriptions.