### PR TITLE
Feature: Utilities for converting values into location queries

### DIFF
--- a/src/useRouteQueryParam/formats/RouteParam.ts
+++ b/src/useRouteQueryParam/formats/RouteParam.ts
@@ -1,5 +1,4 @@
-import { LocationQueryValue } from 'vue-router'
-import { UseRouteQuery } from '@/useRouteQuery/useRouteQuery'
+import { LocationQuery, LocationQueryValue } from 'vue-router'
 import { InvalidRouteParamValue, isInvalidRouteParamValue, isNotInvalidRouteParamValue } from '@/useRouteQueryParam/formats/InvalidRouteParamValue'
 import { asArray } from '@/utilities/arrays'
 
@@ -41,12 +40,12 @@ export abstract class RouteParam<T> {
     this.multiple = multiple || Array.isArray(defaultValue)
   }
 
-  public get(routeQuery: UseRouteQuery): T | T[] | undefined {
-    if (!(this.key in routeQuery.query)) {
+  public get(query: LocationQuery): T | T[] | undefined {
+    if (!(this.key in query)) {
       return this.defaultValue
     }
 
-    const strings = asArray(routeQuery.get(this.key))
+    const strings = asArray(query[this.key])
     const values = strings.map(value => this.safeParseValue(value)).filter(isNotInvalidRouteParamValue)
 
     if (this.multiple) {
@@ -58,25 +57,28 @@ export abstract class RouteParam<T> {
     return first
   }
 
-  public set(routeQuery: UseRouteQuery, value: T | T[] | undefined): void {
+  public set(query: LocationQuery, value: T | T[] | undefined): void {
     if (value === undefined) {
-      return routeQuery.remove(this.key)
+      delete query[this.key]
+      return
     }
 
     const values = asArray(value)
     const strings = values.map(value => this.safeFormatValue(value)).filter(isNotInvalidRouteParamValue)
 
     if (strings.length === 0) {
-      return routeQuery.remove(this.key)
+      delete query[this.key]
+      return
     }
 
     if (this.multiple) {
-      return routeQuery.set(this.key, strings)
+      query[this.key] = strings
+      return
     }
 
     const [first] = strings
 
-    routeQuery.set(this.key, first)
+    query[this.key] = first
   }
 
   private safeParseValue(value: LocationQueryValue): T | InvalidRouteParamValue {

--- a/src/useRouteQueryParam/index.ts
+++ b/src/useRouteQueryParam/index.ts
@@ -1,2 +1,3 @@
-export * from './useRouteQueryParam'
 export * from './formats'
+export * from './useRouteQueryParam'
+export * from './utilities'

--- a/src/useRouteQueryParam/useRouteQueryParam.ts
+++ b/src/useRouteQueryParam/useRouteQueryParam.ts
@@ -37,7 +37,7 @@ export function useRouteQueryParam(key: string, formatterOrDefaultValue?: RouteP
     return useRouteQueryParam(key, StringRouteParam, formatterOrDefaultValue)
   }
 
-  const query = useRouteQuery()
+  const { query } = useRouteQuery()
   const multiple = Array.isArray(formatterOrDefaultValue)
   const [formatter] = asArray(formatterOrDefaultValue)
   const defaultValue = maybeDefaultValue

--- a/src/useRouteQueryParam/utilities/getLocationQueryValueForFormat.ts
+++ b/src/useRouteQueryParam/utilities/getLocationQueryValueForFormat.ts
@@ -1,0 +1,49 @@
+import { LocationQuery, LocationQueryValue } from 'vue-router'
+import { UseRouteQuery } from '@/useRouteQuery/useRouteQuery'
+import { RouteParamClass } from '@/useRouteQueryParam/formats/RouteParam'
+import { asArray } from '@/utilities/arrays'
+
+function useFakeRouteQuery(): UseRouteQuery {
+  const query: LocationQuery = {}
+
+  function clear(): void {
+    for (const prop of Object.getOwnPropertyNames(query)) {
+      delete query[prop]
+    }
+  }
+
+  function set(key: string, value: LocationQueryValue | LocationQueryValue[]): void {
+    query[key] = value
+  }
+
+  function get(key: string): LocationQueryValue | LocationQueryValue[] {
+    return query[key]
+  }
+
+  function remove(key: string): void {
+    delete query[key]
+  }
+
+  return {
+    query,
+    clear,
+    set,
+    get,
+    remove,
+  }
+}
+
+export function getLocationQueryValueForFormat<T>(formatter: RouteParamClass<T>, value: T): LocationQueryValue | LocationQueryValue[]
+export function getLocationQueryValueForFormat<T>(formatter: [RouteParamClass<T>], value: T[]): LocationQueryValue | LocationQueryValue[]
+export function getLocationQueryValueForFormat<T>(formatter: RouteParamClass<T> | [RouteParamClass<T>], value: T | T[]): LocationQueryValue | LocationQueryValue[]
+export function getLocationQueryValueForFormat<T>(formatter: RouteParamClass<T> | [RouteParamClass<T>], value: T | T[]): LocationQueryValue | LocationQueryValue[] {
+  const key = 'dummy-key'
+  const routeQuery = useFakeRouteQuery()
+  const multiple = Array.isArray(formatter)
+  const [FormatterConstructor] = asArray(formatter)
+  const format = new FormatterConstructor({ multiple, key, defaultValue: value })
+
+  format.set(routeQuery, value)
+
+  return routeQuery.query[key]
+}

--- a/src/useRouteQueryParam/utilities/getLocationQueryValueForFormat.ts
+++ b/src/useRouteQueryParam/utilities/getLocationQueryValueForFormat.ts
@@ -1,49 +1,18 @@
 import { LocationQuery, LocationQueryValue } from 'vue-router'
-import { UseRouteQuery } from '@/useRouteQuery/useRouteQuery'
 import { RouteParamClass } from '@/useRouteQueryParam/formats/RouteParam'
 import { asArray } from '@/utilities/arrays'
-
-function useFakeRouteQuery(): UseRouteQuery {
-  const query: LocationQuery = {}
-
-  function clear(): void {
-    for (const prop of Object.getOwnPropertyNames(query)) {
-      delete query[prop]
-    }
-  }
-
-  function set(key: string, value: LocationQueryValue | LocationQueryValue[]): void {
-    query[key] = value
-  }
-
-  function get(key: string): LocationQueryValue | LocationQueryValue[] {
-    return query[key]
-  }
-
-  function remove(key: string): void {
-    delete query[key]
-  }
-
-  return {
-    query,
-    clear,
-    set,
-    get,
-    remove,
-  }
-}
 
 export function getLocationQueryValueForFormat<T>(formatter: RouteParamClass<T>, value: T): LocationQueryValue | LocationQueryValue[]
 export function getLocationQueryValueForFormat<T>(formatter: [RouteParamClass<T>], value: T[]): LocationQueryValue | LocationQueryValue[]
 export function getLocationQueryValueForFormat<T>(formatter: RouteParamClass<T> | [RouteParamClass<T>], value: T | T[]): LocationQueryValue | LocationQueryValue[]
 export function getLocationQueryValueForFormat<T>(formatter: RouteParamClass<T> | [RouteParamClass<T>], value: T | T[]): LocationQueryValue | LocationQueryValue[] {
   const key = 'dummy-key'
-  const routeQuery = useFakeRouteQuery()
+  const query: LocationQuery = {}
   const multiple = Array.isArray(formatter)
   const [FormatterConstructor] = asArray(formatter)
   const format = new FormatterConstructor({ multiple, key, defaultValue: value })
 
-  format.set(routeQuery, value)
+  format.set(query, value)
 
-  return routeQuery.query[key]
+  return query[key]
 }

--- a/src/useRouteQueryParam/utilities/index.ts
+++ b/src/useRouteQueryParam/utilities/index.ts
@@ -1,0 +1,1 @@
+export * from './getLocationQueryValueForFormat'

--- a/src/useRouteQueryParams/index.ts
+++ b/src/useRouteQueryParams/index.ts
@@ -1,1 +1,2 @@
+export * from './utilities'
 export * from './useRouteQueryParams'

--- a/src/useRouteQueryParams/useRouteQueryParams.ts
+++ b/src/useRouteQueryParams/useRouteQueryParams.ts
@@ -25,7 +25,7 @@ export function useRouteQueryParams<T extends AnyRecord>(schema: RouteQueryParam
   return getSchemaRouteQueryParams(schema, defaultValue, prefix)
 }
 
-function isRouteParamSchema<T extends AnyRecord>(value: RouteQueryParamsSchema<T> | unknown): value is RouteQueryParamsSchema<T> {
+export function isRouteParamSchema<T extends AnyRecord>(value: RouteQueryParamsSchema<T> | unknown): value is RouteQueryParamsSchema<T> {
   return !isRouteParamClass(value)
 }
 

--- a/src/useRouteQueryParams/utilities/getLocationQueryForSchema.ts
+++ b/src/useRouteQueryParams/utilities/getLocationQueryForSchema.ts
@@ -1,0 +1,38 @@
+import { LocationQuery } from 'vue-router'
+import { isRouteParamClass, isRouteParamClassTuple } from '@/useRouteQueryParam/formats/RouteParam'
+import { getLocationQueryValueForFormat } from '@/useRouteQueryParam/utilities'
+import { RouteQueryParamsSchema, isRouteParamSchema } from '@/useRouteQueryParams'
+import { isRecord } from '@/utilities/objects'
+
+export function getLocationQueryForSchema<T extends Record<string, unknown>>(schema: RouteQueryParamsSchema<T>, value: T, prefix?: string): LocationQuery {
+  const prefixed = (key: string): string => {
+    if (prefix) {
+      return `${prefix}.${key}`
+    }
+
+    return key
+  }
+
+  const locationQuery: LocationQuery = {}
+
+  Object.keys(schema).forEach(key => {
+    const propertyFormat = schema[key]
+    const propertyKey = prefixed(key)
+    const propertyValue = value[key]
+
+    if (isRouteParamClass(propertyFormat) || isRouteParamClassTuple(propertyFormat)) {
+      locationQuery[propertyKey] = getLocationQueryValueForFormat(propertyFormat, propertyValue)
+      return
+    }
+
+    if (isRouteParamSchema(propertyFormat) && isRecord(propertyValue)) {
+      const nestedLocationQuery = getLocationQueryForSchema(propertyFormat, propertyValue, propertyKey)
+
+      Object.entries(nestedLocationQuery).forEach(([key, value]) => {
+        locationQuery[key] = value
+      })
+    }
+  })
+
+  return locationQuery
+}

--- a/src/useRouteQueryParams/utilities/index.ts
+++ b/src/useRouteQueryParams/utilities/index.ts
@@ -1,0 +1,1 @@
+export * from './getLocationQueryForSchema'


### PR DESCRIPTION
# Description
Introduces two new utility methods based on a conversation with @collincchoy

`getLocationQueryValueForFormat`
Accepts a `RouteParam` and a value and returns the `LocationQueryValue`

`getLocationQueryForSchema`
Accepts a `RouteQueryParamsSchema` and a value and returns the `LocationQuery`