### PR TITLE
Enhancement: Add `onError` callback to subscription options

### DIFF
--- a/src/useSubscription/models/channel.ts
+++ b/src/useSubscription/models/channel.ts
@@ -68,8 +68,6 @@ export default class Channel<T extends Action = Action> {
     return Math.min(...intervals)
   }
 
-  // conflicting rules
-  // eslint-disable-next-line @typescript-eslint/member-ordering
   public get response(): ActionResponse<T> | undefined {
     return this._response
   }
@@ -86,8 +84,6 @@ export default class Channel<T extends Action = Action> {
     }
   }
 
-  // conflicting rules
-  // eslint-disable-next-line @typescript-eslint/member-ordering
   public get executed(): boolean {
     return this._executed
   }
@@ -100,8 +96,6 @@ export default class Channel<T extends Action = Action> {
     }
   }
 
-  // conflicting rules
-  // eslint-disable-next-line @typescript-eslint/member-ordering
   public get loading(): boolean {
     return this._loading
   }
@@ -114,8 +108,6 @@ export default class Channel<T extends Action = Action> {
     }
   }
 
-  // conflicting rules
-  // eslint-disable-next-line @typescript-eslint/member-ordering
   public get errored(): boolean {
     return this._errored
   }
@@ -128,8 +120,6 @@ export default class Channel<T extends Action = Action> {
     }
   }
 
-  // conflicting rules
-  // eslint-disable-next-line @typescript-eslint/member-ordering
   public get error(): unknown {
     return this._error
   }
@@ -185,6 +175,7 @@ export default class Channel<T extends Action = Action> {
       this.errored = true
       this.error = error
       this.clearTimer()
+      this.onError(error)
 
       console.error(error)
     } finally {
@@ -226,5 +217,11 @@ export default class Channel<T extends Action = Action> {
     const timeTillNextExecution = this.interval - sinceLastRun
 
     this.timer = setTimeout(() => this.refresh(), timeTillNextExecution)
+  }
+
+  private onError(error: unknown): void {
+    for (const subscription of this.subscriptions.values()) {
+      subscription.options.onError?.(error)
+    }
   }
 }

--- a/src/useSubscription/types/subscription.ts
+++ b/src/useSubscription/types/subscription.ts
@@ -11,6 +11,7 @@ export type SubscriptionOptions = {
   interval?: number,
   manager?: Manager,
   lifecycle?: 'component' | 'app',
+  onError?: (error: unknown) => void,
 }
 
 export type SubscriptionPromise<T extends Action> = Promise<Omit<UseSubscription<T>, 'promise'> & { response: ActionResponse<T> }>

--- a/src/useSubscription/useSubscription.spec.ts
+++ b/src/useSubscription/useSubscription.spec.ts
@@ -607,4 +607,19 @@ describe('subscribe', () => {
     expect(action).toBeCalledTimes(2)
   })
 
+  it('calls the onError callback when the action errors', async () => {
+    const error = new Error()
+    const onError = vi.fn()
+    const action = (): void => {
+      throw error
+    }
+
+    uniqueSubscribe(action, [], { onError })
+
+    await timeout()
+
+    expect(onError).toBeCalledTimes(1)
+    expect(onError).toBeCalledWith(error)
+  })
+
 })


### PR DESCRIPTION
# Description
Allows an error callback to be provided at implementation. This is a much better method for error processing than checking/watching the `error` and `errored` properties.