### PR TITLE
BugFix: Using the awaited value from `.promise()` breaks subscription refreshing

### DIFF
--- a/src/useSubscription/useSubscription.spec.ts
+++ b/src/useSubscription/useSubscription.spec.ts
@@ -622,4 +622,13 @@ describe('subscribe', () => {
     expect(onError).toBeCalledWith(error)
   })
 
+  it('allows refresh to be called when the a subscription is created with .promise()', async () => {
+    const action = vi.fn()
+    const subscription = await uniqueSubscribe(action).promise()
+
+    subscription.refresh()
+
+    expect(true)
+  })
+
 })

--- a/src/useSubscription/useSubscription.spec.ts
+++ b/src/useSubscription/useSubscription.spec.ts
@@ -628,7 +628,21 @@ describe('subscribe', () => {
 
     subscription.refresh()
 
-    expect(true)
+    expect(action).toBeCalledTimes(2)
+  })
+
+  it('response is reactive when using .promise()', async () => {
+    let value = 0
+    const action = (): number => ++value
+    const subscription = await uniqueSubscribe(action).promise()
+
+    expect(subscription.response).toBe(1)
+
+    subscription.refresh()
+
+    await timeout()
+
+    expect(subscription.response).toBe(2)
   })
 
 })

--- a/src/useSubscription/utilities/subscriptions.ts
+++ b/src/useSubscription/utilities/subscriptions.ts
@@ -1,7 +1,7 @@
 import { reactive } from 'vue'
 import Subscription from '@/useSubscription/models/subscription'
 import { Action } from '@/useSubscription/types/action'
-import { MappedSubscription } from '@/useSubscription/types/subscription'
+import { MappedSubscription, SubscriptionPromise } from '@/useSubscription/types/subscription'
 
 export function mapSubscription<T extends Action>(subscription: Subscription<T>): MappedSubscription<T> {
   const { loading, error, errored, response, executed } = subscription
@@ -15,6 +15,21 @@ export function mapSubscription<T extends Action>(subscription: Subscription<T>)
     refresh: () => subscription.refresh(),
     unsubscribe: () => subscription.unsubscribe(),
     isSubscribed: () => subscription.isSubscribed(),
-    promise: () => subscription.promise().then(subscription => reactive(subscription)),
+    promise: () => subscription.promise().then(subscription => mapSubscriptionPromise(subscription)),
   }
+}
+
+function mapSubscriptionPromise<T extends Action>(subscription: Subscription<T>): Awaited<SubscriptionPromise<T>> {
+  const { loading, error, errored, response, executed } = subscription
+
+  return reactive({
+    loading,
+    error,
+    errored,
+    response,
+    executed,
+    refresh: () => subscription.refresh(),
+    unsubscribe: () => subscription.unsubscribe(),
+    isSubscribed: () => subscription.isSubscribed(),
+  }) as Awaited<SubscriptionPromise<T>>
 }


### PR DESCRIPTION
# Description
An error would be thrown if you awaited the promise and use the subscription that it returned to refresh. 

```typescript
const subscription = await useSubscription(action).promise()

subscription.refresh() // error
```

This was because for the composition the promise value was being returned as `reactive(subscription)` which to make the subscription class instance itself reactive. Which means you end up with ref unwrapping when there shouldn't be. Converting the subscription instance into a reactive object same as what the composition returns fixes this. 