### PR TITLE
ensure default value is used if parsed value is nullish

### DIFF
--- a/src/useStorage/storage.ts
+++ b/src/useStorage/storage.ts
@@ -36,7 +36,7 @@ export class StorageManager {
     }
 
     try {
-      return JSON.parse(value) as T
+      return JSON.parse(value) as T | null ?? defaultValue
     } catch {
       console.error(`Unable to parse current value for key ${key}, returning default instead`)
       return defaultValue


### PR DESCRIPTION
when the key doesn't exist, the value in storage.ts:32

```ts
const value = storage.getItem(key)
```

comes back as `"null"`, which doesn't get caught by `if (value === null) {` on line 34

this PR ensures that if the value is nullish AFTER parsing, the defaultValue is used