### PR TITLE
`useValidation` and `useValidationObserver` - Reset validations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,7 @@
     "isequal",
     "prefecthq"
   ],
+  "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },

--- a/src/useValidation/useValidation.spec.ts
+++ b/src/useValidation/useValidation.spec.ts
@@ -45,12 +45,12 @@ describe('useValidation', () => {
 
     it('triggers automatically when the value changes', async () => {
       const theValue = ref(0)
-      const validationSpy = vi.fn().mockResolvedValue('Validation did not pass')
+      const validationRule = vi.fn().mockResolvedValue('Validation did not pass')
       const wrapper = mount({
         setup() {
           const { valid, error } = useValidation(
             theValue,
-            validationSpy,
+            validationRule,
           )
 
           return { valid, error }
@@ -59,13 +59,13 @@ describe('useValidation', () => {
 
       expect(wrapper.vm.valid).toBe(true)
       expect(wrapper.vm.error).toBe('')
-      expect(validationSpy).not.toHaveBeenCalled()
+      expect(validationRule).not.toHaveBeenCalled()
 
       theValue.value = 1
       await nextTick()
       await flushPromises()
 
-      expect(validationSpy).toHaveBeenCalled()
+      expect(validationRule).toHaveBeenCalled()
       expect(wrapper.vm.error).toBe('Validation did not pass')
       expect(wrapper.vm.valid).toBe(false)
     })

--- a/src/useValidation/useValidation.spec.ts
+++ b/src/useValidation/useValidation.spec.ts
@@ -17,7 +17,6 @@ describe('useValidation', () => {
     it('sets valid to true when the rules pass', async () => {
       const { valid, error, validate } = useValidation(
         ref(1),
-        'Number',
         isGreaterThanZero,
       )
 
@@ -28,16 +27,17 @@ describe('useValidation', () => {
     })
 
     it('sets valid to false with an error message when the rules do not pass', async () => {
+      const errorMessage = 'Validation did not pass'
+      const validationRule: ValidationRule<number> = () => errorMessage
       const { valid, error, validate } = useValidation(
         ref(0),
-        'Number',
-        isGreaterThanZero,
+        validationRule,
       )
 
       await validate()
 
       expect(valid.value).toBe(false)
-      expect(error.value).toBe('Number must be greater than 0')
+      expect(error.value).toBe(errorMessage)
     })
 
     it('triggers automatically when the value changes', async () => {
@@ -111,14 +111,13 @@ describe('useValidation', () => {
     it('resets the validation state', async () => {
       const { state, validate, reset } = useValidation(
         ref(0),
-        'Number',
-        isGreaterThanZero,
+        () => 'Validation did not pass',
       )
 
       await validate()
 
       expect(state.valid).toBe(false)
-      expect(state.error).toBe('Number must be greater than 0')
+      expect(state.error).toBe('Validation did not pass')
 
       reset()
 

--- a/src/useValidation/useValidation.spec.ts
+++ b/src/useValidation/useValidation.spec.ts
@@ -14,9 +14,12 @@ const isGreaterThanZero: ValidationRule<number> = (value, name) => {
 
 describe('useValidation', () => {
   describe('validate', () => {
-    it('sets valid to true when the rules pass', async () => {
+    it.each([
+      { value: 1, valueType: 'plain value' },
+      { value: ref(1), valueType: 'ref' },
+    ])('sets valid to true when the rules pass (with $valueType)', async ({ value }) => {
       const { valid, error, validate } = useValidation(
-        ref(1),
+        value,
         isGreaterThanZero,
       )
 
@@ -26,11 +29,14 @@ describe('useValidation', () => {
       expect(error.value).toBe('')
     })
 
-    it('sets valid to false with an error message when the rules do not pass', async () => {
+    it.each([
+      { value: 0, valueType: 'plain value' },
+      { value: ref(0), valueType: 'ref' },
+    ])('sets valid to false with an error message when the rules do not pass (with $valueType)', async ({ value }) => {
       const errorMessage = 'Validation did not pass'
       const validationRule: ValidationRule<number> = () => errorMessage
       const { valid, error, validate } = useValidation(
-        ref(0),
+        value,
         validationRule,
       )
 

--- a/src/useValidation/useValidation.spec.ts
+++ b/src/useValidation/useValidation.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+import { ValidationRule, useValidation } from '@/useValidation/useValidation'
+
+const isGreaterThanZero: ValidationRule<number> = (value, name) => {
+  if (value > 0) {
+    return true
+  }
+
+  return `${name} must be greater than 0`
+}
+
+describe('useValidation', () => {
+  describe('validate', () => {
+    it('sets valid to true when the rules pass', async () => {
+      const { valid, error, validate } = useValidation(
+        ref(1),
+        'Number',
+        isGreaterThanZero,
+      )
+
+      await validate()
+
+      expect(valid.value).toBe(true)
+      expect(error.value).toBe('')
+    })
+
+    it('sets valid to false with an error message when the rules do not pass', async () => {
+      const { valid, error, validate } = useValidation(
+        ref(0),
+        'Number',
+        isGreaterThanZero,
+      )
+
+      await validate()
+
+      expect(valid.value).toBe(false)
+      expect(error.value).toBe('Number must be greater than 0')
+    })
+  })
+})

--- a/src/useValidation/useValidation.spec.ts
+++ b/src/useValidation/useValidation.spec.ts
@@ -198,14 +198,11 @@ describe('useValidation', () => {
       expect(wrapper.vm.state.error).toBe('')
       expect(validationRule).not.toHaveBeenCalled()
 
-      try {
-        wrapper.vm.reset(() => {
-          theValue.value = 1
-          throw new Error('Something went wrong')
-        })
-      } catch (error) {
-        // ignore
-      }
+      expect(() => wrapper.vm.reset(() => {
+        theValue.value = 1
+        throw new Error('Something went wrong')
+      }),
+      ).toThrowError('Something went wrong')
       await timeout()
 
       expect(validationRule).not.toHaveBeenCalled()

--- a/src/useValidation/useValidation.spec.ts
+++ b/src/useValidation/useValidation.spec.ts
@@ -1,6 +1,7 @@
+/* eslint-disable vue/one-component-per-file */
 import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { defineComponent, ref } from 'vue'
 import { ValidationRule, useValidation } from '@/useValidation/useValidation'
 import { timeout } from '@/utilities/tests'
 
@@ -49,7 +50,9 @@ describe('useValidation', () => {
     it('triggers automatically when the value changes', async () => {
       const theValue = ref(0)
       const validationRule = vi.fn().mockResolvedValue('Validation did not pass')
-      const wrapper = mount({
+      const wrapper = mount(defineComponent({
+        name: 'TestComponent',
+        expose: ['valid', 'error'],
         setup() {
           const { valid, error } = useValidation(
             theValue,
@@ -58,7 +61,7 @@ describe('useValidation', () => {
 
           return { valid, error }
         },
-      })
+      }))
 
       expect(wrapper.vm.valid).toBe(true)
       expect(wrapper.vm.error).toBe('')
@@ -77,7 +80,9 @@ describe('useValidation', () => {
     it('prevents validation from running when paused', async () => {
       const theValue = ref(0)
       const validationRule = vi.fn().mockResolvedValue('Validation did not pass')
-      const wrapper = mount({
+      const wrapper = mount(defineComponent({
+        name: 'TestComponent',
+        expose: ['valid', 'error', 'pause', 'resume'],
         setup() {
           const { valid, error, pause, resume } = useValidation(
             theValue,
@@ -86,7 +91,7 @@ describe('useValidation', () => {
 
           return { valid, error, pause, resume }
         },
-      })
+      }))
 
       expect(wrapper.vm.valid).toBe(true)
       expect(wrapper.vm.error).toBe('')
@@ -135,7 +140,9 @@ describe('useValidation', () => {
         theValue.value = value
         await timeout()
       }
-      const wrapper = mount({
+      const wrapper = mount(defineComponent({
+        name: 'TestComponent',
+        expose: ['state', 'reset', 'pause', 'resume'],
         setup() {
           const { state, reset, pause, resume } = useValidation(
             theValue,
@@ -144,7 +151,7 @@ describe('useValidation', () => {
 
           return { state, reset, pause, resume }
         },
-      })
+      }))
       expect(wrapper.vm.state.valid).toBe(true)
 
       await updateTheValueAndWaitForEffects(-1)
@@ -174,7 +181,9 @@ describe('useValidation', () => {
     it('resumes validation if an error occurs in the reset callback', async () => {
       const theValue = ref(0)
       const validationRule = vi.fn().mockResolvedValue('Validation did not pass')
-      const wrapper = mount({
+      const wrapper = mount(defineComponent({
+        name: 'TestComponent',
+        expose: ['state', 'reset'],
         setup() {
           const { state, reset } = useValidation(
             theValue,
@@ -183,7 +192,7 @@ describe('useValidation', () => {
 
           return { state, reset }
         },
-      })
+      }))
 
       expect(wrapper.vm.state.valid).toBe(true)
       expect(wrapper.vm.state.error).toBe('')

--- a/src/useValidation/useValidation.spec.ts
+++ b/src/useValidation/useValidation.spec.ts
@@ -2,7 +2,7 @@ import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { ValidationRule, useValidation } from '@/useValidation/useValidation'
-import { flushPromises } from '@/utilities/tests'
+import { timeout } from '@/utilities/tests'
 
 const isGreaterThanZero: ValidationRule<number> = (value, name) => {
   if (value > 0) {
@@ -59,7 +59,7 @@ describe('useValidation', () => {
       expect(validationRule).not.toHaveBeenCalled()
 
       theValue.value = 1
-      await flushPromises()
+      await timeout()
 
       expect(validationRule).toHaveBeenCalled()
       expect(wrapper.vm.error).toBe('Validation did not pass')
@@ -88,7 +88,7 @@ describe('useValidation', () => {
 
       wrapper.vm.pause()
       theValue.value = 1
-      await flushPromises()
+      await timeout()
 
       expect(validationRule).not.toHaveBeenCalled()
       expect(wrapper.vm.error).toBe('')
@@ -96,7 +96,7 @@ describe('useValidation', () => {
 
       wrapper.vm.resume()
       theValue.value = 2
-      await flushPromises()
+      await timeout()
 
       expect(validationRule).toHaveBeenCalled()
       expect(wrapper.vm.error).toBe('Validation did not pass')
@@ -127,7 +127,7 @@ describe('useValidation', () => {
       const theValue = ref(0)
       async function updateTheValueAndWaitForEffects(value: number): Promise<void> {
         theValue.value = value
-        await flushPromises()
+        await timeout()
       }
       const wrapper = mount({
         setup() {
@@ -156,7 +156,7 @@ describe('useValidation', () => {
       expect(wrapper.vm.state.valid).toBe(true)
 
       wrapper.vm.reset(() => theValue.value = 0)
-      await flushPromises()
+      await timeout()
       expect(theValue.value).toBe(0)
       expect(wrapper.vm.state.valid).toBe(true)
 
@@ -191,14 +191,14 @@ describe('useValidation', () => {
       } catch (error) {
         // ignore
       }
-      await flushPromises()
+      await timeout()
 
       expect(validationRule).not.toHaveBeenCalled()
       expect(wrapper.vm.state.valid).toBe(true)
 
       // watcher resumed
       theValue.value = 2
-      await flushPromises()
+      await timeout()
       expect(validationRule).toHaveBeenCalled()
     })
   })

--- a/src/useValidation/useValidation.spec.ts
+++ b/src/useValidation/useValidation.spec.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
 import { ValidationRule, useValidation } from '@/useValidation/useValidation'
+
+function flushPromises(): Promise<void> {
+  return new Promise(setImmediate)
+}
 
 const isGreaterThanZero: ValidationRule<number> = (value, name) => {
   if (value > 0) {
@@ -37,6 +42,33 @@ describe('useValidation', () => {
       expect(valid.value).toBe(false)
       expect(error.value).toBe('Number must be greater than 0')
     })
+
+    it('triggers automatically when the value changes', async () => {
+      const theValue = ref(0)
+      const validationSpy = vi.fn().mockResolvedValue('Validation did not pass')
+      const wrapper = mount({
+        setup() {
+          const { valid, error } = useValidation(
+            theValue,
+            validationSpy,
+          )
+
+          return { valid, error }
+        },
+      })
+
+      expect(wrapper.vm.valid).toBe(true)
+      expect(wrapper.vm.error).toBe('')
+      expect(validationSpy).not.toHaveBeenCalled()
+
+      theValue.value = 1
+      await nextTick()
+      await flushPromises()
+
+      expect(validationSpy).toHaveBeenCalled()
+      expect(wrapper.vm.error).toBe('Validation did not pass')
+      expect(wrapper.vm.valid).toBe(false)
+    })
   })
 
   describe('reset', () => {
@@ -57,6 +89,46 @@ describe('useValidation', () => {
       expect(state.valid).toBe(true)
       expect(state.error).toBe('')
       expect(state.validated).toBe(false)
+    })
+
+    it('resets the validation state and optionally skips the next onChange validate', async () => {
+      const theValue = ref(0)
+      async function updateTheValueAndWaitForEffects(value: number): Promise<void> {
+        theValue.value = value
+        await nextTick()
+        await flushPromises()
+      }
+      const wrapper = mount({
+        setup() {
+          const { state, reset } = useValidation(
+            theValue,
+            isGreaterThanZero,
+          )
+
+          return { state, reset }
+        },
+      })
+      expect(wrapper.vm.state.valid).toBe(true)
+
+      await updateTheValueAndWaitForEffects(-1)
+      expect(wrapper.vm.state.valid).toBe(false)
+
+      // when skipNextValidateOnChange is not true, changing the value triggers validations again
+      wrapper.vm.reset()
+      expect(wrapper.vm.state.valid).toBe(true)
+
+      await updateTheValueAndWaitForEffects(0)
+      expect(wrapper.vm.state.valid).toBe(false)
+
+      // now try with skipNextValidateOnChange: true
+      await updateTheValueAndWaitForEffects(1)
+      expect(wrapper.vm.state.valid).toBe(true)
+
+      wrapper.vm.reset({ skipNextValidateOnChange: true })
+      expect(wrapper.vm.state.valid).toBe(true)
+
+      await updateTheValueAndWaitForEffects(0)
+      expect(wrapper.vm.state.valid).toBe(true)
     })
   })
 })

--- a/src/useValidation/useValidation.spec.ts
+++ b/src/useValidation/useValidation.spec.ts
@@ -38,4 +38,25 @@ describe('useValidation', () => {
       expect(error.value).toBe('Number must be greater than 0')
     })
   })
+
+  describe('reset', () => {
+    it('resets the validation state', async () => {
+      const { state, validate, reset } = useValidation(
+        ref(0),
+        'Number',
+        isGreaterThanZero,
+      )
+
+      await validate()
+
+      expect(state.valid).toBe(false)
+      expect(state.error).toBe('Number must be greater than 0')
+
+      reset()
+
+      expect(state.valid).toBe(true)
+      expect(state.error).toBe('')
+      expect(state.validated).toBe(false)
+    })
+  })
 })

--- a/src/useValidation/useValidation.spec.ts
+++ b/src/useValidation/useValidation.spec.ts
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
-import { nextTick, ref } from 'vue'
+import { ref } from 'vue'
 import { ValidationRule, useValidation } from '@/useValidation/useValidation'
 import { flushPromises } from '@/utilities/tests'
 
@@ -59,7 +59,6 @@ describe('useValidation', () => {
       expect(validationRule).not.toHaveBeenCalled()
 
       theValue.value = 1
-      await nextTick()
       await flushPromises()
 
       expect(validationRule).toHaveBeenCalled()
@@ -89,7 +88,6 @@ describe('useValidation', () => {
 
       wrapper.vm.pause()
       theValue.value = 1
-      await nextTick()
       await flushPromises()
 
       expect(validationRule).not.toHaveBeenCalled()
@@ -98,7 +96,6 @@ describe('useValidation', () => {
 
       wrapper.vm.resume()
       theValue.value = 2
-      await nextTick()
       await flushPromises()
 
       expect(validationRule).toHaveBeenCalled()
@@ -130,7 +127,6 @@ describe('useValidation', () => {
       const theValue = ref(0)
       async function updateTheValueAndWaitForEffects(value: number): Promise<void> {
         theValue.value = value
-        await nextTick()
         await flushPromises()
       }
       const wrapper = mount({
@@ -160,7 +156,6 @@ describe('useValidation', () => {
       expect(wrapper.vm.state.valid).toBe(true)
 
       wrapper.vm.reset(() => theValue.value = 0)
-      await nextTick()
       await flushPromises()
       expect(theValue.value).toBe(0)
       expect(wrapper.vm.state.valid).toBe(true)

--- a/src/useValidation/useValidation.ts
+++ b/src/useValidation/useValidation.ts
@@ -21,7 +21,16 @@ export type ValidateMethodOptions = {
 }
 
 export type ValidateMethod = (options?: ValidateMethodOptions) => Promise<boolean>
-export type ResetMethod = () => void
+
+export type ResetMethodOptions = {
+  /**
+   * If true, the next call to validate will not be called.
+   * This allows you to reset validation state and then reset the value
+   * without triggering another validation.
+   */
+  skipNextValidateOnChange?: boolean,
+}
+export type ResetMethod = (options?: ResetMethodOptions) => void
 
 export type UseValidation = ToRefs<UseValidationState> & {
   validate: ValidateMethod,
@@ -100,10 +109,15 @@ export function useValidation<T>(
     return valid.value
   }
 
-  const reset: ResetMethod = () => {
+  let skipNextValidateOnChange = false
+  const reset: ResetMethod = (options) => {
     error.value = ''
     pending.value = false
     validated.value = false
+
+    if (options?.skipNextValidateOnChange) {
+      skipNextValidateOnChange = true
+    }
   }
 
   const state = reactive({
@@ -129,6 +143,11 @@ export function useValidation<T>(
 
   watch(valueRef, (newValue, oldValue) => {
     if (!mounted) {
+      return
+    }
+
+    if (skipNextValidateOnChange) {
+      skipNextValidateOnChange = false
       return
     }
 

--- a/src/useValidation/useValidation.ts
+++ b/src/useValidation/useValidation.ts
@@ -35,6 +35,8 @@ export type ResetMethod = (options?: ResetMethodOptions) => void
 export type UseValidation = ToRefs<UseValidationState> & {
   validate: ValidateMethod,
   reset: ResetMethod,
+  pause: () => void,
+  resume: () => void,
   state: UseValidationState,
 }
 
@@ -120,6 +122,15 @@ export function useValidation<T>(
     }
   }
 
+  let paused = false
+  const pause = (): void => {
+    paused = true
+  }
+
+  const resume = (): void => {
+    paused = false
+  }
+
   const state = reactive({
     valid,
     invalid,
@@ -136,6 +147,8 @@ export function useValidation<T>(
     validated,
     validate,
     reset,
+    pause,
+    resume,
     state,
   }
 
@@ -148,6 +161,10 @@ export function useValidation<T>(
 
     if (skipNextValidateOnChange) {
       skipNextValidateOnChange = false
+      return
+    }
+
+    if (paused) {
       return
     }
 

--- a/src/useValidation/useValidation.ts
+++ b/src/useValidation/useValidation.ts
@@ -118,8 +118,11 @@ export function useValidation<T>(
 
     if (resetCallback) {
       pause()
-      resetCallback()
-      resume()
+      try {
+        resetCallback()
+      } finally {
+        resume()
+      }
     }
   }
 

--- a/src/useValidation/useValidation.ts
+++ b/src/useValidation/useValidation.ts
@@ -24,9 +24,10 @@ export type ValidateMethod = (options?: ValidateMethodOptions) => Promise<boolea
 
 export type ResetMethodParams = [
   /**
-   * If true, the next call to validate will not be called.
+   * An optional callback that will be called within a pause/resume block.
    * This allows you to reset validation state and then reset the value
-   * without triggering another validation.
+   * without triggering another validation on change.
+   * For example if a value is required, use `reset(() => valueRef.value = undefined)`.
    */
   resetCallback?: () => void
 ]

--- a/src/useValidation/useValidation.ts
+++ b/src/useValidation/useValidation.ts
@@ -21,9 +21,11 @@ export type ValidateMethodOptions = {
 }
 
 export type ValidateMethod = (options?: ValidateMethodOptions) => Promise<boolean>
+export type ResetMethod = () => void
 
 export type UseValidation = ToRefs<UseValidationState> & {
   validate: ValidateMethod,
+  reset: ResetMethod,
   state: UseValidationState,
 }
 
@@ -98,6 +100,12 @@ export function useValidation<T>(
     return valid.value
   }
 
+  const reset: ResetMethod = () => {
+    error.value = ''
+    pending.value = false
+    validated.value = false
+  }
+
   const state = reactive({
     valid,
     invalid,
@@ -113,6 +121,7 @@ export function useValidation<T>(
     pending,
     validated,
     validate,
+    reset,
     state,
   }
 

--- a/src/useValidation/useValidation.ts
+++ b/src/useValidation/useValidation.ts
@@ -132,6 +132,9 @@ export function useValidation<T>(
   }
 
   const resume = (): void => {
+    if (stopWatch) {
+      return
+    }
     startWatcher()
   }
 

--- a/src/useValidationObserver/useValidationObserver.spec.ts
+++ b/src/useValidationObserver/useValidationObserver.spec.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 import { useValidation } from '@/useValidation'
 import { useValidationObserver } from '@/useValidationObserver'
+import { flushPromises } from '@/utilities/tests'
 
 describe('useValidationObserver', () => {
   it('should observe a single useValidation', async () => {
@@ -107,14 +108,12 @@ describe('useValidationObserver', () => {
       expect(wrapper.vm.valid).toBe(false)
       expect(wrapper.vm.errors).toHaveLength(1)
 
-      wrapper.vm.reset({ skipNextValidateOnChange: true })
+      validationRule.mockClear()
+      wrapper.vm.reset(() => value.value = undefined)
       expect(wrapper.vm.valid).toBe(true)
       expect(wrapper.vm.errors).toHaveLength(0)
 
-      validationRule.mockClear()
-
-      value.value = undefined
-      await nextTick()
+      await flushPromises()
 
       expect(validationRule).not.toHaveBeenCalled()
       expect(wrapper.vm.valid).toBe(true)
@@ -123,8 +122,7 @@ describe('useValidationObserver', () => {
       validationRule.mockClear()
       // the next value change should trigger validation
       value.value = 1
-      await nextTick()
-      await new Promise(setImmediate)
+      await flushPromises()
 
       expect(validationRule).toHaveBeenCalled()
       expect(wrapper.vm.valid).toBe(false)

--- a/src/useValidationObserver/useValidationObserver.spec.ts
+++ b/src/useValidationObserver/useValidationObserver.spec.ts
@@ -6,11 +6,11 @@ import { useValidationObserver } from '@/useValidationObserver'
 
 describe('useValidationObserver', () => {
   it('should observe a single useValidation', async () => {
-    const validationSpy = vi.fn().mockResolvedValue(true)
+    const validationRule = vi.fn().mockResolvedValue(true)
     const wrapper = mount({
       setup() {
         const { validate } = useValidationObserver()
-        useValidation(ref(0), validationSpy)
+        useValidation(ref(0), validationRule)
         return { validate }
       },
     })
@@ -18,17 +18,17 @@ describe('useValidationObserver', () => {
     const result = await wrapper.vm.validate()
 
     expect(result).toBe(true)
-    expect(validationSpy).toHaveBeenCalled()
+    expect(validationRule).toHaveBeenCalled()
   })
 
   it('should observe multiple useValidations', async () => {
-    const validationSpy1 = vi.fn().mockResolvedValue(true)
-    const validationSpy2 = vi.fn().mockResolvedValue(true)
+    const validationRule1 = vi.fn().mockResolvedValue(true)
+    const validationRule2 = vi.fn().mockResolvedValue(true)
     const wrapper = mount({
       setup() {
         const { validate } = useValidationObserver()
-        useValidation(ref(0), validationSpy1)
-        useValidation(ref(0), validationSpy2)
+        useValidation(ref(0), validationRule1)
+        useValidation(ref(0), validationRule2)
 
         return { validate }
       },
@@ -37,8 +37,8 @@ describe('useValidationObserver', () => {
     const result = await wrapper.vm.validate()
 
     expect(result).toBe(true)
-    expect(validationSpy1).toHaveBeenCalled()
-    expect(validationSpy2).toHaveBeenCalled()
+    expect(validationRule1).toHaveBeenCalled()
+    expect(validationRule2).toHaveBeenCalled()
   })
 
   it('should observe multiple useValidations and be invalid if any does not pass', async () => {
@@ -63,13 +63,13 @@ describe('useValidationObserver', () => {
 
   describe('reset', () => {
     it('should reset all observed validation states when reset is called', async () => {
-      const validationRule1Spy = vi.fn().mockResolvedValue(true)
-      const validationRule2Spy = vi.fn().mockResolvedValue('Number must be greater than 0')
+      const validationRule1 = vi.fn().mockResolvedValue(true)
+      const validationRule2 = vi.fn().mockResolvedValue('Number must be greater than 0')
       const wrapper = mount({
         setup() {
           const { validate, reset, valid, errors } = useValidationObserver()
-          useValidation(ref(0), validationRule1Spy)
-          useValidation(ref(0), validationRule2Spy)
+          useValidation(ref(0), validationRule1)
+          useValidation(ref(0), validationRule2)
 
           return { validate, reset, valid, errors }
         },
@@ -90,11 +90,11 @@ describe('useValidationObserver', () => {
     it('should reset and allow the value to be reset without rerunning validations', async () => {
       const value = ref<number | undefined>(0)
       // this validator will always fail. testing that calling reset allows the value to be reset without revalidating
-      const validationRuleSpy = vi.fn().mockResolvedValue('Number must be greater than 0')
+      const validationRule = vi.fn().mockResolvedValue('Number must be greater than 0')
       const wrapper = mount({
         setup() {
           const { validate, reset, valid, errors } = useValidationObserver()
-          useValidation(value, validationRuleSpy)
+          useValidation(value, validationRule)
 
           return { validate, reset, valid, errors }
         },
@@ -111,22 +111,22 @@ describe('useValidationObserver', () => {
       expect(wrapper.vm.valid).toBe(true)
       expect(wrapper.vm.errors).toHaveLength(0)
 
-      validationRuleSpy.mockClear()
+      validationRule.mockClear()
 
       value.value = undefined
       await nextTick()
 
-      expect(validationRuleSpy).not.toHaveBeenCalled()
+      expect(validationRule).not.toHaveBeenCalled()
       expect(wrapper.vm.valid).toBe(true)
       expect(wrapper.vm.errors).toHaveLength(0)
 
-      validationRuleSpy.mockClear()
+      validationRule.mockClear()
       // the next value change should trigger validation
       value.value = 1
       await nextTick()
       await new Promise(setImmediate)
 
-      expect(validationRuleSpy).toHaveBeenCalled()
+      expect(validationRule).toHaveBeenCalled()
       expect(wrapper.vm.valid).toBe(false)
     })
   })

--- a/src/useValidationObserver/useValidationObserver.spec.ts
+++ b/src/useValidationObserver/useValidationObserver.spec.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { ref } from 'vue'
 import { useValidation } from '@/useValidation'
 import { useValidationObserver } from '@/useValidationObserver'
-import { flushPromises } from '@/utilities/tests'
+import { timeout } from '@/utilities/tests'
 
 describe('useValidationObserver', () => {
   it('should observe a single useValidation', async () => {
@@ -113,7 +113,7 @@ describe('useValidationObserver', () => {
       expect(wrapper.vm.valid).toBe(true)
       expect(wrapper.vm.errors).toHaveLength(0)
 
-      await flushPromises()
+      await timeout()
 
       expect(validationRule).not.toHaveBeenCalled()
       expect(wrapper.vm.valid).toBe(true)
@@ -122,7 +122,7 @@ describe('useValidationObserver', () => {
       validationRule.mockClear()
       // the next value change should trigger validation
       value.value = 1
-      await flushPromises()
+      await timeout()
 
       expect(validationRule).toHaveBeenCalled()
       expect(wrapper.vm.valid).toBe(false)

--- a/src/useValidationObserver/useValidationObserver.spec.ts
+++ b/src/useValidationObserver/useValidationObserver.spec.ts
@@ -1,0 +1,63 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+import { ref } from 'vue'
+import { useValidation } from '@/useValidation'
+import { useValidationObserver } from '@/useValidationObserver'
+
+describe('useValidationObserver', () => {
+  it('should observe a single useValidation', async () => {
+    const validationSpy = vi.fn().mockResolvedValue(true)
+    const wrapper = mount({
+      setup() {
+        const { validate } = useValidationObserver()
+        useValidation(ref(0), 'Number', validationSpy)
+        return { validate }
+      },
+    })
+
+    const result = await wrapper.vm.validate()
+
+    expect(result).toBe(true)
+    expect(validationSpy).toHaveBeenCalled()
+  })
+
+  it('should observe multiple useValidations', async () => {
+    const validationSpy1 = vi.fn().mockResolvedValue(true)
+    const validationSpy2 = vi.fn().mockResolvedValue(true)
+    const wrapper = mount({
+      setup() {
+        const { validate } = useValidationObserver()
+        useValidation(ref(0), 'Number', validationSpy1)
+        useValidation(ref(0), 'Number', validationSpy2)
+
+        return { validate }
+      },
+    })
+
+    const result = await wrapper.vm.validate()
+
+    expect(result).toBe(true)
+    expect(validationSpy1).toHaveBeenCalled()
+    expect(validationSpy2).toHaveBeenCalled()
+  })
+
+  it('should observe multiple useValidations and be invalid if any does not pass', async () => {
+    const validationRule1Spy = vi.fn().mockResolvedValue(true)
+    const validationRule2Spy = vi.fn().mockResolvedValue(false)
+    const wrapper = mount({
+      setup() {
+        const { validate } = useValidationObserver()
+        useValidation(ref(0), 'Number', validationRule1Spy)
+        useValidation(ref(0), 'Number', validationRule2Spy)
+
+        return { validate }
+      },
+    })
+
+    const result = await wrapper.vm.validate()
+
+    expect(result).toBe(false)
+    expect(validationRule1Spy).toHaveBeenCalled()
+    expect(validationRule2Spy).toHaveBeenCalled()
+  })
+})

--- a/src/useValidationObserver/useValidationObserver.spec.ts
+++ b/src/useValidationObserver/useValidationObserver.spec.ts
@@ -1,6 +1,7 @@
+/* eslint-disable vue/one-component-per-file */
 import { mount } from '@vue/test-utils'
 import { describe, it, expect, vi } from 'vitest'
-import { ref } from 'vue'
+import { defineComponent, ref } from 'vue'
 import { useValidation } from '@/useValidation'
 import { useValidationObserver } from '@/useValidationObserver'
 import { timeout } from '@/utilities/tests'
@@ -8,13 +9,15 @@ import { timeout } from '@/utilities/tests'
 describe('useValidationObserver', () => {
   it('should observe a single useValidation', async () => {
     const validationRule = vi.fn().mockResolvedValue(true)
-    const wrapper = mount({
+    const wrapper = mount(defineComponent({
+      name: 'TestComponent',
+      expose: ['validate'],
       setup() {
         const { validate } = useValidationObserver()
         useValidation(0, validationRule)
         return { validate }
       },
-    })
+    }))
 
     const result = await wrapper.vm.validate()
 
@@ -25,7 +28,9 @@ describe('useValidationObserver', () => {
   it('should observe multiple useValidations', async () => {
     const validationRule1 = vi.fn().mockResolvedValue(true)
     const validationRule2 = vi.fn().mockResolvedValue(true)
-    const wrapper = mount({
+    const wrapper = mount(defineComponent({
+      name: 'TestComponent',
+      expose: ['validate'],
       setup() {
         const { validate } = useValidationObserver()
         useValidation(0, validationRule1)
@@ -33,7 +38,7 @@ describe('useValidationObserver', () => {
 
         return { validate }
       },
-    })
+    }))
 
     const result = await wrapper.vm.validate()
 
@@ -45,7 +50,9 @@ describe('useValidationObserver', () => {
   it('should observe multiple useValidations and be invalid if any does not pass', async () => {
     const validationRule1Spy = vi.fn().mockResolvedValue(true)
     const validationRule2Spy = vi.fn().mockResolvedValue(false)
-    const wrapper = mount({
+    const wrapper = mount(defineComponent({
+      name: 'TestComponent',
+      expose: ['validate'],
       setup() {
         const { validate } = useValidationObserver()
         useValidation(0, validationRule1Spy)
@@ -53,7 +60,7 @@ describe('useValidationObserver', () => {
 
         return { validate }
       },
-    })
+    }))
 
     const result = await wrapper.vm.validate()
 
@@ -66,7 +73,9 @@ describe('useValidationObserver', () => {
     it('should reset all observed validation states when reset is called', async () => {
       const validationRule1 = vi.fn().mockResolvedValue(true)
       const validationRule2 = vi.fn().mockResolvedValue(false)
-      const wrapper = mount({
+      const wrapper = mount(defineComponent({
+        name: 'TestComponent',
+        expose: ['validate'],
         setup() {
           const { validate, reset, valid, errors } = useValidationObserver()
           useValidation(ref(0), validationRule1)
@@ -74,7 +83,7 @@ describe('useValidationObserver', () => {
 
           return { validate, reset, valid, errors }
         },
-      })
+      }))
 
       // initial, pre-validated state should be true
       expect(wrapper.vm.valid).toBe(true)
@@ -92,14 +101,16 @@ describe('useValidationObserver', () => {
       const value = ref<number | undefined>(0)
       // this validator will always fail. testing that calling reset allows the value to be reset without revalidating
       const validationRule = vi.fn().mockResolvedValue(false)
-      const wrapper = mount({
+      const wrapper = mount(defineComponent({
+        name: 'TestComponent',
+        expose: ['validate'],
         setup() {
           const { validate, reset, valid, errors } = useValidationObserver()
           useValidation(value, validationRule)
 
           return { validate, reset, valid, errors }
         },
-      })
+      }))
 
       // initial, pre-validated state should be true
       expect(wrapper.vm.valid).toBe(true)

--- a/src/useValidationObserver/useValidationObserver.spec.ts
+++ b/src/useValidationObserver/useValidationObserver.spec.ts
@@ -10,7 +10,7 @@ describe('useValidationObserver', () => {
     const wrapper = mount({
       setup() {
         const { validate } = useValidationObserver()
-        useValidation(ref(0), 'Number', validationSpy)
+        useValidation(ref(0), validationSpy)
         return { validate }
       },
     })
@@ -27,8 +27,8 @@ describe('useValidationObserver', () => {
     const wrapper = mount({
       setup() {
         const { validate } = useValidationObserver()
-        useValidation(ref(0), 'Number', validationSpy1)
-        useValidation(ref(0), 'Number', validationSpy2)
+        useValidation(ref(0), validationSpy1)
+        useValidation(ref(0), validationSpy2)
 
         return { validate }
       },
@@ -43,12 +43,12 @@ describe('useValidationObserver', () => {
 
   it('should observe multiple useValidations and be invalid if any does not pass', async () => {
     const validationRule1Spy = vi.fn().mockResolvedValue(true)
-    const validationRule2Spy = vi.fn().mockResolvedValue(false)
+    const validationRule2Spy = vi.fn().mockResolvedValue('Number must be greater than 0')
     const wrapper = mount({
       setup() {
         const { validate } = useValidationObserver()
-        useValidation(ref(0), 'Number', validationRule1Spy)
-        useValidation(ref(0), 'Number', validationRule2Spy)
+        useValidation(ref(0), validationRule1Spy)
+        useValidation(ref(0), validationRule2Spy)
 
         return { validate }
       },
@@ -59,5 +59,30 @@ describe('useValidationObserver', () => {
     expect(result).toBe(false)
     expect(validationRule1Spy).toHaveBeenCalled()
     expect(validationRule2Spy).toHaveBeenCalled()
+  })
+
+  it('should reset all observed validation states when reset is called', async () => {
+    const validationRule1Spy = vi.fn().mockResolvedValue(true)
+    const validationRule2Spy = vi.fn().mockResolvedValue('Number must be greater than 0')
+    const wrapper = mount({
+      setup() {
+        const { validate, reset, valid, errors } = useValidationObserver()
+        useValidation(ref(0), validationRule1Spy)
+        useValidation(ref(0), validationRule2Spy)
+
+        return { validate, reset, valid, errors }
+      },
+    })
+
+    // initial, pre-validated state should be true
+    expect(wrapper.vm.valid).toBe(true)
+
+    await wrapper.vm.validate()
+    expect(wrapper.vm.valid).toBe(false)
+    expect(wrapper.vm.errors).toHaveLength(1)
+
+    wrapper.vm.reset()
+    expect(wrapper.vm.valid).toBe(true)
+    expect(wrapper.vm.errors).toHaveLength(0)
   })
 })

--- a/src/useValidationObserver/useValidationObserver.spec.ts
+++ b/src/useValidationObserver/useValidationObserver.spec.ts
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils'
 import { describe, it, expect, vi } from 'vitest'
-import { nextTick, ref } from 'vue'
+import { ref } from 'vue'
 import { useValidation } from '@/useValidation'
 import { useValidationObserver } from '@/useValidationObserver'
 import { flushPromises } from '@/utilities/tests'

--- a/src/useValidationObserver/useValidationObserver.spec.ts
+++ b/src/useValidationObserver/useValidationObserver.spec.ts
@@ -44,7 +44,7 @@ describe('useValidationObserver', () => {
 
   it('should observe multiple useValidations and be invalid if any does not pass', async () => {
     const validationRule1Spy = vi.fn().mockResolvedValue(true)
-    const validationRule2Spy = vi.fn().mockResolvedValue('Number must be greater than 0')
+    const validationRule2Spy = vi.fn().mockResolvedValue(false)
     const wrapper = mount({
       setup() {
         const { validate } = useValidationObserver()
@@ -65,7 +65,7 @@ describe('useValidationObserver', () => {
   describe('reset', () => {
     it('should reset all observed validation states when reset is called', async () => {
       const validationRule1 = vi.fn().mockResolvedValue(true)
-      const validationRule2 = vi.fn().mockResolvedValue('Number must be greater than 0')
+      const validationRule2 = vi.fn().mockResolvedValue(false)
       const wrapper = mount({
         setup() {
           const { validate, reset, valid, errors } = useValidationObserver()
@@ -91,7 +91,7 @@ describe('useValidationObserver', () => {
     it('should reset and allow the value to be reset without rerunning validations', async () => {
       const value = ref<number | undefined>(0)
       // this validator will always fail. testing that calling reset allows the value to be reset without revalidating
-      const validationRule = vi.fn().mockResolvedValue('Number must be greater than 0')
+      const validationRule = vi.fn().mockResolvedValue(false)
       const wrapper = mount({
         setup() {
           const { validate, reset, valid, errors } = useValidationObserver()

--- a/src/useValidationObserver/useValidationObserver.spec.ts
+++ b/src/useValidationObserver/useValidationObserver.spec.ts
@@ -11,7 +11,7 @@ describe('useValidationObserver', () => {
     const wrapper = mount({
       setup() {
         const { validate } = useValidationObserver()
-        useValidation(ref(0), validationRule)
+        useValidation(0, validationRule)
         return { validate }
       },
     })
@@ -28,8 +28,8 @@ describe('useValidationObserver', () => {
     const wrapper = mount({
       setup() {
         const { validate } = useValidationObserver()
-        useValidation(ref(0), validationRule1)
-        useValidation(ref(0), validationRule2)
+        useValidation(0, validationRule1)
+        useValidation(0, validationRule2)
 
         return { validate }
       },
@@ -48,8 +48,8 @@ describe('useValidationObserver', () => {
     const wrapper = mount({
       setup() {
         const { validate } = useValidationObserver()
-        useValidation(ref(0), validationRule1Spy)
-        useValidation(ref(0), validationRule2Spy)
+        useValidation(0, validationRule1Spy)
+        useValidation(0, validationRule2Spy)
 
         return { validate }
       },

--- a/src/useValidationObserver/useValidationObserver.ts
+++ b/src/useValidationObserver/useValidationObserver.ts
@@ -4,6 +4,7 @@ import { UseValidation } from '@/useValidation/useValidation'
 export type UseValidationObserver = {
   register: ValidationObserverRegister,
   validate: () => Promise<boolean>,
+  reset: () => void,
   valid: ComputedRef<boolean>,
   invalid: ComputedRef<boolean>,
   errors: ComputedRef<string[]>,
@@ -46,6 +47,14 @@ export function useValidationObserver(): UseValidationObserver {
     return Promise.all(promises).then(results => results.every(valid => valid))
   }
 
+  const reset = (): void => {
+    const keys = Reflect.ownKeys(validations) as symbol[]
+
+    for (const key of keys) {
+      validations[key].reset()
+    }
+  }
+
   const errors = computed<string[]>(() => {
     const keys = Reflect.ownKeys(validations) as symbol[]
     return keys
@@ -76,6 +85,7 @@ export function useValidationObserver(): UseValidationObserver {
     invalid,
     pending,
     validate,
+    reset,
     register,
   }
 

--- a/src/useValidationObserver/useValidationObserver.ts
+++ b/src/useValidationObserver/useValidationObserver.ts
@@ -47,11 +47,11 @@ export function useValidationObserver(): UseValidationObserver {
     return Promise.all(promises).then(results => results.every(valid => valid))
   }
 
-  const reset: ResetMethod = (options) => {
+  const reset: ResetMethod = (resetCallback) => {
     const keys = Reflect.ownKeys(validations) as symbol[]
 
     for (const key of keys) {
-      validations[key].reset(options)
+      validations[key].reset(resetCallback)
     }
   }
 

--- a/src/useValidationObserver/useValidationObserver.ts
+++ b/src/useValidationObserver/useValidationObserver.ts
@@ -4,6 +4,8 @@ import { ResetMethod, UseValidation } from '@/useValidation/useValidation'
 export type UseValidationObserver = {
   register: ValidationObserverRegister,
   validate: () => Promise<boolean>,
+  pause: () => void,
+  resume: () => void,
   reset: ResetMethod,
   valid: ComputedRef<boolean>,
   invalid: ComputedRef<boolean>,
@@ -47,6 +49,22 @@ export function useValidationObserver(): UseValidationObserver {
     return Promise.all(promises).then(results => results.every(valid => valid))
   }
 
+  const pause = (): void => {
+    const keys = Reflect.ownKeys(validations) as symbol[]
+
+    for (const key of keys) {
+      validations[key].pause()
+    }
+  }
+
+  const resume = (): void => {
+    const keys = Reflect.ownKeys(validations) as symbol[]
+
+    for (const key of keys) {
+      validations[key].resume()
+    }
+  }
+
   const reset: ResetMethod = (resetCallback) => {
     const keys = Reflect.ownKeys(validations) as symbol[]
 
@@ -85,6 +103,8 @@ export function useValidationObserver(): UseValidationObserver {
     invalid,
     pending,
     validate,
+    pause,
+    resume,
     reset,
     register,
   }

--- a/src/useValidationObserver/useValidationObserver.ts
+++ b/src/useValidationObserver/useValidationObserver.ts
@@ -1,10 +1,10 @@
 import { computed, ComputedRef, inject, InjectionKey, onUnmounted, provide, reactive, UnwrapNestedRefs } from 'vue'
-import { UseValidation } from '@/useValidation/useValidation'
+import { ResetMethod, UseValidation } from '@/useValidation/useValidation'
 
 export type UseValidationObserver = {
   register: ValidationObserverRegister,
   validate: () => Promise<boolean>,
-  reset: () => void,
+  reset: ResetMethod,
   valid: ComputedRef<boolean>,
   invalid: ComputedRef<boolean>,
   errors: ComputedRef<string[]>,
@@ -47,11 +47,11 @@ export function useValidationObserver(): UseValidationObserver {
     return Promise.all(promises).then(results => results.every(valid => valid))
   }
 
-  const reset = (): void => {
+  const reset: ResetMethod = (options) => {
     const keys = Reflect.ownKeys(validations) as symbol[]
 
     for (const key of keys) {
-      validations[key].reset()
+      validations[key].reset(options)
     }
   }
 

--- a/src/utilities/tests.ts
+++ b/src/utilities/tests.ts
@@ -8,6 +8,10 @@ export function timeout(ms = 0): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
+export function flushPromises(): Promise<void> {
+  return new Promise(setImmediate)
+}
+
 export function uniqueSubscribe<T extends Action>(...[action, args, optionsArg = {}]: SubscribeArguments<T>): UseSubscription<T> {
   const options = computed(() => {
     const options = unref(optionsArg)

--- a/src/utilities/tests.ts
+++ b/src/utilities/tests.ts
@@ -8,10 +8,6 @@ export function timeout(ms = 0): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
-export function flushPromises(): Promise<void> {
-  return new Promise(setImmediate)
-}
-
 export function uniqueSubscribe<T extends Action>(...[action, args, optionsArg = {}]: SubscribeArguments<T>): UseSubscription<T> {
   const options = computed(() => {
     const options = unref(optionsArg)


### PR DESCRIPTION
## The Problem
`useValidation` and `useValidationObserver` are lazy by default and don't trigger until their watched value changes. This is convenient so that initially, the value(s) can be "invalid" but validations have yet to run so there are no errors like in the case of an empty form with required fields. 

However in the same example of having a form with required fields, once the values have been modified, there isn't currently a way to reset the internal `useValidation` (and consequently `useValidationObserver`) state to reset the form back to its initial state (without any validation errors). 

## The Proposed Solution
This PR adds a `reset` method to both useValidation and useValidationObserver. Both methods have the same signature where the latter simply loops over all registered validations and applies the respective reset with parameters drilled down.

It looks like:
```typescript
const value = ref(0)
const { valid, error, reset, validate } = useValidation(value, isEvenNumber)
console.log(valid)  // true

value.value = 1
await validate()
console.log(valid)  // false

reset()
console.log(valid)  // true
```

## An extra wrinkle
So resetting the internal state is great, but what about when the value is reset also? Well because `useValidation` watches the passed in value and automatically re-validates on change, just calling `reset()` like above isn't enough. 

Consider the following code:
```typescript
const value = ref<number | undefined>(undefined)
const { valid, error, reset, validate } = useValidation(value, isEvenNumber)
console.log(valid)  // true
await validate()
console.log(valid)  // false because value is undefined

value.value = 1
await validate()
console.log(valid)  // false

reset()
console.log(valid)  // true but `value.value` is still 1
value.value = undefined
console.log(valid)  // false because validations reran automatically on change
console.log(error)  // non-empty error message
```
When used for form validations, on resetting the form, the above code ends up with an extra round of validations done on the reset value which could add/leave validation messages onscreen.

To get around this, I've added 2 more exposed functions to `useValidation` - `pause` and `resume`. When called, the automatic validation on value change is temporarily paused/resumed respectively. Additionally, the reset method can take an optional callback parameter which runs in between a `pause` and `resume` block so that a consumer can run code without triggering the change effect. 

```typescript
const value = ref<number | undefined>(undefined)
const { valid, error, reset, validate } = useValidation(value, isEvenNumber)
console.log(valid)  // true
await validate()
console.log(valid)  // false because value is undefined

value.value = 1
await validate()
console.log(valid)  // false

reset(() => value.value = undefined)
console.log(valid)  // true
console.log(error)  // empty ""
```

> **Warning**
> The rest of this description is OUTDATED. It's been left here for historical purposes. Changes were made in an attempt to smooth out some of the "sharp edges". Namely that the `reset` method can now take a callback function which should automatically run within a paused validation context and resume afterwards. 

<strike>To get around this, I've added an opt-in flag to the reset method which skips the next on-change-validation execution to allow a consumer to update the value once without triggering validations.

```typescript
const value = ref<number | undefined>(undefined)
const { valid, error, reset, validate } = useValidation(value, isEvenNumber)
console.log(valid)  // true
await validate()
console.log(valid)  // false because value is undefined

value.value = 1
await validate()
console.log(valid)  // false

reset({ skipNextValidateOnChange: true })
console.log(valid)  // true but `value.value` is still 1
value.value = undefined
console.log(valid)  // true
console.log(error)  // empty ''
```

## The sharp edges
On the one hand this now gives a consumer the ability to reset validations and supports the use-case I outlined above for resetting the value along with any related validation state.

On the other hand, this seems a little clunky of an api and also there's potential for race conditions if done out-of-order -- `reset` should ideally be called _before_ the values themselves are updated otherwise the `skipNextValidateOnChange` might not be in effect by the time the watcher's effect triggers.
</strike>