### PR TITLE
Revert changes from #332

### DIFF
--- a/src/useRouteQueryParam/useRouteQueryParam.ts
+++ b/src/useRouteQueryParam/useRouteQueryParam.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/unified-signatures */
-import isEqual from 'lodash.isequal'
-import { ref, Ref, watch } from 'vue'
+
+import { computed, Ref } from 'vue'
 import { NoInfer } from '@/types/generics'
 import { MaybeArray } from '@/types/maybe'
 import { useRouteQuery } from '@/useRouteQuery/useRouteQuery'
@@ -44,21 +44,13 @@ export function useRouteQueryParam(key: string, formatterOrDefaultValue?: RouteP
   const defaultValue = maybeDefaultValue
   const format = new formatter({ key, defaultValue, multiple })
 
-  const param = ref(format.get(query))
 
-  watch(() => query, query => {
-    const newValue = format.get(query)
-
-    if (isEqual(newValue, param)) {
-      return
-    }
-
-    param.value = newValue
+  return computed({
+    get() {
+      return format.get(query)
+    },
+    set(value) {
+      format.set(query, value)
+    },
   })
-
-  watch(param, param => {
-    format.set(query, param)
-  })
-
-  return param
 }


### PR DESCRIPTION
Reverts changes from #332 as it broke reactivity for some pages (see https://github.com/PrefectHQ/prefect/issues/11061 for more details).  The underlying issue that #332 aimed to address still needs research but this PR should un lock vue-compostions for any future releases. 