### PR TITLE
Fix useRouteQuery reactivity

### DIFF
--- a/src/useRouteQuery/useRouteQuery.ts
+++ b/src/useRouteQuery/useRouteQuery.ts
@@ -24,8 +24,7 @@ function factory(): () => UseRouteQuery {
   let interval: ReturnType<typeof setTimeout>
 
   const update = async (): Promise<void> => {
-    const operationsToApply = operations.slice(0)
-    const query = applyQueryOperations(route.query, operationsToApply)
+    const query = applyQueryOperations(route.query, operations)
 
     await router.push({ query })
 

--- a/src/useRouteQuery/useRouteQuery.ts
+++ b/src/useRouteQuery/useRouteQuery.ts
@@ -24,10 +24,12 @@ function factory(): () => UseRouteQuery {
   let interval: ReturnType<typeof setTimeout>
 
   const update = async (): Promise<void> => {
-    const operationsToApply = operations.splice(0)
+    const operationsToApply = operations.slice(0)
     const query = applyQueryOperations(route.query, operationsToApply)
 
     await router.push({ query })
+
+    operations.splice(0)
   }
 
   watch(operations, () => {


### PR DESCRIPTION
# Description
`useRouteQuery` works by creating an array of operations to apply to the query and then updating the query in batches. But when the operations were flushed to the actual route the operations were being cleared before updating the route. This resulted in individual query params flipping from the new value to the old value and then back to the new value. 

## Reproduction
```vue
<template>
  <button type="button" @click="testing">click me</button>
</template>

<script setup lang="ts">
  const tab = useRouteQueryParam('tab')

  watch(tab, () => {
    console.log('tab changed', tab.value)
  })

  function testing(): void {
    tab.value = randomId()
  }
</script>
```

Result
```
tab changed bd123e4b-75e2-41bd-bd20-39c53a246fe7. ---- (new)
tab changed 93b2ba30-2797-4c78-ab38-7d987913bc05 ---- (old)
tab changed bd123e4b-75e2-41bd-bd20-39c53a246fe7 ---- (new)
```

Expected
```
tab changed bd123e4b-75e2-41bd-bd20-39c53a246fe7. ---- (new)
```

## Fix
Waiting to clear the operations from the queue until after they have been applied to the route fixes the issue. 

Thank you @collincchoy for the reproduction and debugging you did on https://github.com/PrefectHQ/vue-compositions/pull/332 which was a bandaid fix that we ultimately reverted because it caused other issues. 