### PR TITLE
Fix subscription actions being called even when the args have not changed

### DIFF
--- a/src/useSubscription/useSubscriptionWithDependencies.spec.ts
+++ b/src/useSubscription/useSubscriptionWithDependencies.spec.ts
@@ -4,14 +4,10 @@ import { useSubscriptionWithDependencies } from '@/useSubscription/useSubscripti
 import { timeout } from '@/utilities/tests'
 
 test('it does not execute the action when args have not changed', async () => {
-  const number = ref(0)
   const object = ref({ value: 0 })
   const action = vi.fn()
 
-  const parameters = computed(() => [
-    number.value,
-    object.value,
-  ])
+  const parameters = computed(() => [object.value])
 
   useSubscriptionWithDependencies(action, parameters)
 
@@ -19,14 +15,12 @@ test('it does not execute the action when args have not changed', async () => {
 
   expect(action).toBeCalledTimes(1)
 
-  number.value = 1
   object.value = { value: 1 }
 
   await timeout()
 
   expect(action).toBeCalledTimes(2)
 
-  number.value = 1
   object.value = { value: 1 }
 
   await timeout()

--- a/src/useSubscription/useSubscriptionWithDependencies.spec.ts
+++ b/src/useSubscription/useSubscriptionWithDependencies.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test, vi } from 'vitest'
+import { computed, ref } from 'vue'
+import { useSubscriptionWithDependencies } from '@/useSubscription/useSubscriptionWithDependencies'
+import { timeout } from '@/utilities/tests'
+
+test('it does not execute the action when args have not changed', async () => {
+  const number = ref(0)
+  const object = ref({ value: 0 })
+  const action = vi.fn()
+
+  const parameters = computed(() => [
+    number.value,
+    object.value,
+  ])
+
+  useSubscriptionWithDependencies(action, parameters)
+
+  await timeout()
+
+  expect(action).toBeCalledTimes(1)
+
+  number.value = 1
+  object.value = { value: 1 }
+
+  await timeout()
+
+  expect(action).toBeCalledTimes(2)
+
+  number.value = 1
+  object.value = { value: 1 }
+
+  await timeout()
+
+  expect(action).toBeCalledTimes(2)
+})

--- a/src/useSubscription/useSubscriptionWithDependencies.ts
+++ b/src/useSubscription/useSubscriptionWithDependencies.ts
@@ -1,3 +1,4 @@
+import isEqual from 'lodash.isequal'
 import { reactive, ref, Ref, toRaw, watch } from 'vue'
 import { MaybeRef } from '@/types/maybe'
 import { Action, SubscriptionOptions, UseSubscription, ActionArguments, MappedSubscription } from '@/useSubscription/types'
@@ -30,6 +31,10 @@ export function useSubscriptionWithDependencies<T extends Action>(...[action, ar
 
   watch(args, (value: Parameters<T> | null, previousValue: Parameters<T> | null | undefined) => {
     if (value === null && previousValue === undefined) {
+      return
+    }
+
+    if (isEqual(value, previousValue)) {
       return
     }
 


### PR DESCRIPTION
# Description
`useSubscription` has a safe guard in its action arguments watcher to avoid creating new subscriptions when the args haven't actually changed. Not in a strict `===` manor but in a `{ value: 1 }` is the same as another object with the exact contents. 

`useSubscriptionWithDependencies` did not have this same protection. So adding a `isEqual` check on arguments prevents the subscription from being unsubscribed and recreated unnecessarily.

The unit test I added failed without the `isEqual` check. 