### PR TITLE
Add some jsdoc for better IDE devX

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,7 @@
   ],
   "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "editor.tabSize": 2,
   "editor.insertSpaces": true,

--- a/src/useSubscription/README.md
+++ b/src/useSubscription/README.md
@@ -1,5 +1,5 @@
 # useSubscription
-The `useSubscription` composition manages data sharing across components. Multiple components can subscribe to an `action` (any method or function) and and share the response value. 
+The `useSubscription` composition manages data sharing across components. Multiple components can subscribe to an `action` (any method or function) and share the response value. 
 
 ## Example
 ```typescript

--- a/src/useSubscription/types/subscription.ts
+++ b/src/useSubscription/types/subscription.ts
@@ -8,6 +8,7 @@ export type SubscribeArguments<T extends Action> = ActionParamsRequired<T> exten
   : [action: T, args: ActionArguments<T>, options?: MaybeRef<SubscriptionOptions>]
 
 export type SubscriptionOptions = {
+  /** The maximum time in milliseconds before the subscription is considered stale and refreshes. Defaults to `Infinity` */
   interval?: number,
   manager?: Manager,
   lifecycle?: 'component' | 'app',
@@ -29,13 +30,20 @@ export type MappedSubscription<T extends Action> = {
 }
 
 export type UseSubscription<T extends Action> = {
+  /** Set to `true` while the action is being executed. Initially `false`. */
   loading: boolean,
+  /** Return value from the `action` after execution. Initially `undefined`. */
   response: ActionResponse<T> | undefined,
+  /** Set to `true` if there is an error when executing the action. Initially `false`. */
   errored: boolean,
+  /** Stores any error thrown while executing the action. Initially `null`. */
   error: unknown,
   executed: boolean,
+  /** Executes the `action` again. */
   refresh: Subscription<T>['refresh'],
+  /** Remove the subscription from the channel. */
   unsubscribe: Subscription<T>['unsubscribe'],
   isSubscribed: Subscription<T>['isSubscribed'],
+  /** Returns a promise that resolves when the `response` is returned. */
   promise: () => SubscriptionPromise<T>,
 }

--- a/src/useSubscription/useSubscription.ts
+++ b/src/useSubscription/useSubscription.ts
@@ -32,19 +32,6 @@ const defaultManager = new Manager()
  *
  * @param action - The function to be executed.
  * @param args - Parameters of the action being executed.
- * @param options - An object containing optional parameters.
- * @param options.interval - A max poll interval in milliseconds.
- * @param options.manager - A channel manager to use for the subscription.
- *
- * @returns An object containing the following properties:
- * - `loading`: Set to `true` while the action is being executed.
- * - `errored`: Set to `true` if there is an error when executing the action.
- * - `error`: Stores any error thrown while executing the action.
- * - `response`: Return value from the `action` after execution.
- * - `refresh`: Executes the `action` again.
- * - `promise`: Returns a promise that resolves when the `response` is returned.
- * - `unsubscribe`: Remove the subscription from the channel.
- * - `subscribe`: Resubscribes to the channel using the same arguments.
  */
 export function useSubscription<T extends Action>(
   ...[action, args, optionsArg = {}]: SubscribeArguments<T>

--- a/src/useSubscription/useSubscription.ts
+++ b/src/useSubscription/useSubscription.ts
@@ -9,7 +9,46 @@ import { uniqueValueWatcher } from '@/utilities/uniqueValueWatcher'
 
 const defaultManager = new Manager()
 
-export function useSubscription<T extends Action>(...[action, args, optionsArg = {}]: SubscribeArguments<T>): UseSubscription<T> {
+/**
+ * The `useSubscription` composition manages data sharing across components. Multiple components can subscribe to an `action` (any method or function) and share the response value.
+ *
+ * @example
+ * ```typescript
+ * import { useSubscription } from '@prefecthq/vue-compositions'
+ *
+ * const subscription = useSubscription(action, args, options)
+ * ```
+ *
+ * ## How it works
+ * When creating a subscription for the first time a `Channel` is created. A channel is unique to both the `action` and the `args` used to create the subscription. When a channel is created it immediately executes the action with the given args. If `options.interval` is set the action will execute again at that interval updating the `loading`, `errored`, `error`, and `response` values automatically.
+ *
+ * If another subscription is created with the same action and args, it will not execute the action again. Instead the same channel will be reused. So if multiple components subscribe using the same args the action will only be executed once.
+ *
+ * If any subscriptions have `options.interval` then the shortest interval will be used. All subscriptions will received an updated response at the decided interval, even if a specific subscription has no interval or if it has a greater interval. Interval is basically "maximum age of execution" which defaults to `Infinity`.
+ *
+ * When a subscription is removed the channel interval is recalculated. A subscription can be removed by calling `subscription.unsubscribe()` or the subscription will automatically be removed when the component that created the subscription is unmounted.
+ *
+ * @see [README](https://github.com/PrefectHQ/vue-compositions/tree/main/src/useSubscription#readme)
+ *
+ * @param action - The function to be executed.
+ * @param args - Parameters of the action being executed.
+ * @param options - An object containing optional parameters.
+ * @param options.interval - A max poll interval in milliseconds.
+ * @param options.manager - A channel manager to use for the subscription.
+ *
+ * @returns An object containing the following properties:
+ * - `loading`: Set to `true` while the action is being executed.
+ * - `errored`: Set to `true` if there is an error when executing the action.
+ * - `error`: Stores any error thrown while executing the action.
+ * - `response`: Return value from the `action` after execution.
+ * - `refresh`: Executes the `action` again.
+ * - `promise`: Returns a promise that resolves when the `response` is returned.
+ * - `unsubscribe`: Remove the subscription from the channel.
+ * - `subscribe`: Resubscribes to the channel using the same arguments.
+ */
+export function useSubscription<T extends Action>(
+  ...[action, args, optionsArg = {}]: SubscribeArguments<T>
+): UseSubscription<T> {
   const options = unref(optionsArg)
   const manager = options.manager ?? defaultManager
   const argsWithDefault = args ?? [] as unknown as ActionArguments<T>

--- a/src/useSubscription/useSubscription.ts
+++ b/src/useSubscription/useSubscription.ts
@@ -12,23 +12,7 @@ const defaultManager = new Manager()
 /**
  * The `useSubscription` composition manages data sharing across components. Multiple components can subscribe to an `action` (any method or function) and share the response value.
  *
- * @example
- * ```typescript
- * import { useSubscription } from '@prefecthq/vue-compositions'
- *
- * const subscription = useSubscription(action, args, options)
- * ```
- *
- * ## How it works
- * When creating a subscription for the first time a `Channel` is created. A channel is unique to both the `action` and the `args` used to create the subscription. When a channel is created it immediately executes the action with the given args. If `options.interval` is set the action will execute again at that interval updating the `loading`, `errored`, `error`, and `response` values automatically.
- *
- * If another subscription is created with the same action and args, it will not execute the action again. Instead the same channel will be reused. So if multiple components subscribe using the same args the action will only be executed once.
- *
- * If any subscriptions have `options.interval` then the shortest interval will be used. All subscriptions will received an updated response at the decided interval, even if a specific subscription has no interval or if it has a greater interval. Interval is basically "maximum age of execution" which defaults to `Infinity`.
- *
- * When a subscription is removed the channel interval is recalculated. A subscription can be removed by calling `subscription.unsubscribe()` or the subscription will automatically be removed when the component that created the subscription is unmounted.
- *
- * @see [README](https://github.com/PrefectHQ/vue-compositions/tree/main/src/useSubscription#readme)
+ * @see [docs](https://github.com/PrefectHQ/vue-compositions/tree/main/src/useSubscription#readme)
  *
  * @param action - The function to be executed.
  * @param args - Parameters of the action being executed.

--- a/src/useSubscription/useSubscriptionWithDependencies.ts
+++ b/src/useSubscription/useSubscriptionWithDependencies.ts
@@ -26,6 +26,14 @@ function toRawSubscription<T extends Action>(subscription: UseSubscription<T>): 
   return toRaw(subscription) as unknown as MappedSubscription<T>
 }
 
+/**
+ * Similar to `useSubscription` but delays executing the action if args is null.
+ *
+ * This is useful for when you want to use a subscription but the arguments are not available yet (e.g. the result of a promise).
+ * A common use case is for chaining subscriptions so that the second subscription is only executed after the first one is done.
+ *
+ * @see [`useSubscription`](https://github.com/PrefectHQ/vue-compositions/tree/main/src/useSubscription#readme) for more details.
+ */
 export function useSubscriptionWithDependencies<T extends Action>(...[action, args, options = {}]: UseSubscriptionWithDependencies<T>): UseSubscription<T | typeof voidAction> {
   const subscription = reactive(rawVoidSubscription())
 

--- a/src/useValidation/useValidation.ts
+++ b/src/useValidation/useValidation.ts
@@ -22,24 +22,30 @@ export type ValidateMethodOptions = {
 
 export type ValidateMethod = (options?: ValidateMethodOptions) => Promise<boolean>
 
-export type ResetMethodParams = [
-  /**
-   * An optional callback that will be called within a pause/resume block.
-   * This allows you to reset validation state and then reset the value
-   * without triggering another validation on change.
-   * For example if a value is required, use `reset(() => valueRef.value = undefined)`.
-   */
-  resetCallback?: () => void
-]
-export type ResetMethod = (...params: ResetMethodParams) => void
-
 export type UseValidation = ToRefs<UseValidationState> & {
   validate: ValidateMethod,
-  reset: ResetMethod,
+  /**
+   * Reset the validation state.
+  *
+  * @param resetCallback An optional callback that will be called within a pause/resume block.
+  *   This allows you to reset validation state and then reset the value without triggering
+  *   another validation on change.
+  *
+  * @example
+  * ```ts
+  * const value = ref(0)
+  * const { reset } = useValidation(value, isGreaterThanZero)
+  * reset(() => value.value = 0)
+  * ```
+  */
+  // eslint-disable-next-line @typescript-eslint/method-signature-style -- JSDoc in IDE doesn't work nearly as well with a property
+  reset(resetCallback?: () => void): void,
   pause: () => void,
   resume: () => void,
   state: UseValidationState,
 }
+
+export type ResetMethod = UseValidation['reset']
 
 export type ValidationRuleContext<T> = {
   signal: AbortSignal,

--- a/src/useValidationObserver/useValidationObserver.ts
+++ b/src/useValidationObserver/useValidationObserver.ts
@@ -6,6 +6,11 @@ export type UseValidationObserver = {
   validate: () => Promise<boolean>,
   pause: () => void,
   resume: () => void,
+  /**
+   * Reset all observed validations' states.
+   *
+   * @see UseValidation['reset']
+   */
   reset: ResetMethod,
   valid: ComputedRef<boolean>,
   invalid: ComputedRef<boolean>,


### PR DESCRIPTION
# Description
This PR introduces JSDoc strings in a couple of places to improve devX when consuming the following functions in other projects downstream. 

### `useSubscription`

 https://github.com/PrefectHQ/vue-compositions/assets/22418768/7e4bd17b-80f4-4743-8cb5-b4de9d99a9c0 

### `useSubscriptionWithDependencies`
<img width="701" alt="image" src="https://github.com/PrefectHQ/vue-compositions/assets/22418768/0e0ef462-b00d-4b8a-928d-def42d952e49">

### `useValidation` 
https://github.com/PrefectHQ/vue-compositions/assets/22418768/9a400f4e-9097-4523-ac1d-34671e3ff74e

### `useValidationObserver`
https://github.com/PrefectHQ/vue-compositions/assets/22418768/71c8c621-2a07-4e41-9537-dae100f40e3d


