### PR TITLE
Enhancement: Add pause/resume functionality to subscriptions

### DIFF
--- a/src/useSubscription/models/channel.ts
+++ b/src/useSubscription/models/channel.ts
@@ -48,7 +48,7 @@ export default class Channel<T extends Action = Action> {
   private scope = effectScope()
   private timer: ReturnType<typeof setInterval> | null = null
   private lastExecution: number = 0
-  private late: boolean = false
+  private _late: boolean = false
   private _paused: boolean = false
   private _loading: boolean = false
   private _executed: boolean = false
@@ -84,8 +84,24 @@ export default class Channel<T extends Action = Action> {
   public set paused(paused: boolean) {
     this._paused = paused
 
+    for (const subscription of this.subscriptions.values()) {
+      subscription.paused.value = paused
+    }
+
     if (this.late) {
       this.execute()
+    }
+  }
+
+  private get late(): boolean {
+    return this._late
+  }
+
+  private set late(late: boolean) {
+    this._late = late
+
+    for (const subscription of this.subscriptions.values()) {
+      subscription.late.value = late
     }
   }
 

--- a/src/useSubscription/models/channel.ts
+++ b/src/useSubscription/models/channel.ts
@@ -91,6 +91,12 @@ export default class Channel<T extends Action = Action> {
     if (this.late) {
       this.refresh()
     }
+
+    useSubscriptionDevtools.updateChannel(this, {
+      title: `${this.actionName} · Paused`,
+      data: { channel: this, action: this.actionName, paused },
+      groupId: this.signature,
+    })
   }
 
   private get late(): boolean {
@@ -103,6 +109,12 @@ export default class Channel<T extends Action = Action> {
     for (const subscription of this.subscriptions.values()) {
       subscription.late.value = late
     }
+
+    useSubscriptionDevtools.updateChannel(this, {
+      title: `${this.actionName} · Late`,
+      data: { channel: this, action: this.actionName, late },
+      groupId: this.signature,
+    })
   }
 
   public get response(): ActionResponse<T> | undefined {

--- a/src/useSubscription/models/channel.ts
+++ b/src/useSubscription/models/channel.ts
@@ -89,7 +89,7 @@ export default class Channel<T extends Action = Action> {
     }
 
     if (this.late) {
-      this.execute()
+      this.refresh()
     }
   }
 

--- a/src/useSubscription/models/channel.ts
+++ b/src/useSubscription/models/channel.ts
@@ -88,7 +88,7 @@ export default class Channel<T extends Action = Action> {
       subscription.paused.value = paused
     }
 
-    if (this.late) {
+    if (!paused && this.late) {
       this.refresh()
     }
 

--- a/src/useSubscription/models/manager.ts
+++ b/src/useSubscription/models/manager.ts
@@ -24,6 +24,18 @@ export default class Manager {
     return subscription
   }
 
+  public pause(): void {
+    for (const channel of this.channels.values()) {
+      channel.paused = true
+    }
+  }
+
+  public resume(): void {
+    for (const channel of this.channels.values()) {
+      channel.paused = false
+    }
+  }
+
   public deleteChannel(signature: ChannelSignature): void {
     const channel = this.channels.get(signature)
     if (channel) {
@@ -53,4 +65,5 @@ export default class Manager {
 
     useSubscriptionDevtools.addChannel(channel)
   }
+
 }

--- a/src/useSubscription/models/subscription.ts
+++ b/src/useSubscription/models/subscription.ts
@@ -21,6 +21,8 @@ export default class Subscription<T extends Action> {
   public errored: Ref<boolean> = ref(false)
   public error: Ref<unknown> = ref(null)
   public executed: Ref<boolean> = ref(false)
+  public paused: Ref<boolean> = ref(false)
+  public late: Ref<boolean> = ref(false)
 
   private readonly channel: Channel<T>
 

--- a/src/useSubscription/types/subscription.ts
+++ b/src/useSubscription/types/subscription.ts
@@ -23,6 +23,8 @@ export type MappedSubscription<T extends Action> = {
   errored: Subscription<T>['errored'],
   error: Subscription<T>['error'],
   executed: Subscription<T>['executed'],
+  paused: Subscription<T>['paused'],
+  late: Subscription<T>['late'],
   refresh: Subscription<T>['refresh'],
   unsubscribe: Subscription<T>['unsubscribe'],
   isSubscribed: Subscription<T>['isSubscribed'],
@@ -39,6 +41,10 @@ export type UseSubscription<T extends Action> = {
   /** Stores any error thrown while executing the action. Initially `null`. */
   error: unknown,
   executed: boolean,
+  /** Set to `true` if the channel is paused an is not executing */
+  paused: boolean,
+  /** Set to `true` if an execution was requested while the channel was paused */
+  late: boolean,
   /** Executes the `action` again. */
   refresh: Subscription<T>['refresh'],
   /** Remove the subscription from the channel. */

--- a/src/useSubscription/useSubscription.spec.ts
+++ b/src/useSubscription/useSubscription.spec.ts
@@ -645,14 +645,14 @@ describe('subscribe', () => {
     expect(subscription.response).toBe(2)
   })
 
-  it('doest not execute if paused', () => {
+  it('doest not execute if paused', async () => {
     vi.useFakeTimers()
 
     const interval = 1000
     const manager = new Manager()
     const action = vi.fn()
 
-    useSubscription(action, [], { manager, interval })
+    const subscription = useSubscription(action, [], { manager, interval })
 
     expect(action).toBeCalledTimes(1)
 
@@ -662,13 +662,24 @@ describe('subscribe', () => {
 
     manager.pause()
 
+    expect(subscription.paused).toBe(true)
+
     vi.advanceTimersByTime(interval)
+
+    expect(subscription.late).toBe(true)
 
     expect(action).toBeCalledTimes(2)
 
     manager.resume()
 
     expect(action).toBeCalledTimes(3)
+    expect(subscription.paused).toBe(false)
+
+    vi.useRealTimers()
+
+    await timeout()
+
+    expect(subscription.late).toBe(false)
   })
 
 })

--- a/src/useSubscription/useSubscription.spec.ts
+++ b/src/useSubscription/useSubscription.spec.ts
@@ -645,4 +645,30 @@ describe('subscribe', () => {
     expect(subscription.response).toBe(2)
   })
 
+  it('doest not execute if paused', () => {
+    vi.useFakeTimers()
+
+    const interval = 1000
+    const manager = new Manager()
+    const action = vi.fn()
+
+    useSubscription(action, [], { manager, interval })
+
+    expect(action).toBeCalledTimes(1)
+
+    vi.advanceTimersByTime(interval)
+
+    expect(action).toBeCalledTimes(2)
+
+    manager.pause()
+
+    vi.advanceTimersByTime(interval)
+
+    expect(action).toBeCalledTimes(2)
+
+    manager.resume()
+
+    expect(action).toBeCalledTimes(3)
+  })
+
 })

--- a/src/useSubscription/useSubscription.ts
+++ b/src/useSubscription/useSubscription.ts
@@ -7,7 +7,7 @@ import { getValidWatchSource } from '@/utilities/getValidWatchSource'
 import { tryOnScopeDispose } from '@/utilities/tryOnScopeDispose'
 import { uniqueValueWatcher } from '@/utilities/uniqueValueWatcher'
 
-const defaultManager = new Manager()
+export const defaultSubscriptionManager = new Manager()
 
 /**
  * The `useSubscription` composition manages data sharing across components. Multiple components can subscribe to an `action` (any method or function) and share the response value.
@@ -21,7 +21,7 @@ export function useSubscription<T extends Action>(
   ...[action, args, optionsArg = {}]: SubscribeArguments<T>
 ): UseSubscription<T> {
   const options = unref(optionsArg)
-  const manager = options.manager ?? defaultManager
+  const manager = options.manager ?? defaultSubscriptionManager
   const argsWithDefault = args ?? [] as unknown as ActionArguments<T>
   const originalSubscription = manager.subscribe(action, argsWithDefault, options)
   const subscriptionResponse = reactive(mapSubscription(originalSubscription))
@@ -51,7 +51,7 @@ export function useSubscription<T extends Action>(
     }
 
     const options = unref(optionsArg)
-    const manager = options.manager ?? defaultManager
+    const manager = options.manager ?? defaultSubscriptionManager
     const newSubscription = manager.subscribe(action, argsWithDefault, options)
     subscriptionResponse.unsubscribe()
 

--- a/src/useSubscription/useSubscriptionDevtools.ts
+++ b/src/useSubscription/useSubscriptionDevtools.ts
@@ -120,7 +120,7 @@ export function addChannel(channel: Channel): void {
   refresh()
 }
 
-type UpdateChannelEventTypes = 'Loading' | 'Error' | 'Executed' | 'Response' | 'Refresh'
+export type UpdateChannelEventTypes = 'Loading' | 'Error' | 'Executed' | 'Response' | 'Refresh' | 'Paused' | 'Late'
 type UpdateChannelEvent = {
   [K in UpdateChannelEventTypes]: CreateSubscriptionDevtoolsTimelineEvent<K, EventTypeToDataMap[K]>
 }[UpdateChannelEventTypes]
@@ -221,6 +221,8 @@ type EventTypeToDataMap = {
   'Executed': { channel: Channel, action: string, executed: boolean },
   'Response': { channel: Channel, action: string, response: unknown },
   'Refresh': { channel: Channel, action: string },
+  'Paused': { channel: Channel, action: string, paused: boolean },
+  'Late': { channel: Channel, action: string, late: boolean },
 }
 
 type SubscriptionDevtoolsTimelineEvent = {

--- a/src/useSubscription/utilities/subscriptions.ts
+++ b/src/useSubscription/utilities/subscriptions.ts
@@ -4,7 +4,7 @@ import { Action } from '@/useSubscription/types/action'
 import { MappedSubscription, SubscriptionPromise } from '@/useSubscription/types/subscription'
 
 export function mapSubscription<T extends Action>(subscription: Subscription<T>): MappedSubscription<T> {
-  const { loading, error, errored, response, executed } = subscription
+  const { loading, error, errored, response, executed, paused, late } = subscription
 
   return {
     loading,
@@ -12,6 +12,8 @@ export function mapSubscription<T extends Action>(subscription: Subscription<T>)
     errored,
     response,
     executed,
+    paused,
+    late,
     refresh: () => subscription.refresh(),
     unsubscribe: () => subscription.unsubscribe(),
     isSubscribed: () => subscription.isSubscribed(),
@@ -20,7 +22,7 @@ export function mapSubscription<T extends Action>(subscription: Subscription<T>)
 }
 
 function mapSubscriptionPromise<T extends Action>(subscription: Subscription<T>): Awaited<SubscriptionPromise<T>> {
-  const { loading, error, errored, response, executed } = subscription
+  const { loading, error, errored, response, executed, paused, late } = subscription
 
   return reactive({
     loading,
@@ -28,6 +30,8 @@ function mapSubscriptionPromise<T extends Action>(subscription: Subscription<T>)
     errored,
     response,
     executed,
+    paused,
+    late,
     refresh: () => subscription.refresh(),
     unsubscribe: () => subscription.unsubscribe(),
     isSubscribed: () => subscription.isSubscribed(),


### PR DESCRIPTION
# Description
Adds the ability for `Manager` to pause and resume all of the active channels. This will allow us to automatically pause making requests when a tab or window has been backgrounded. 

```typescript
import { defaultSubscriptionManager } from '@prefecthq/vue-compositions'

// logic for when pause should happen omitted
defaultSubscriptionManager.pause()
```

When a channel is paused it will not execute the action. If an action execution is requested (either via refresh or an interval poll) the channel is marked as `late`. When a channel is resumed if it missed an execution while it was paused and is in a late state, it will immediately execute the action via a refresh.

Individual subscriptions have a reactive `paused` and `late` property that reflects the state of the channel. 