### PR TITLE
Update subscription exports

### DIFF
--- a/src/useSubscription/models/channel.ts
+++ b/src/useSubscription/models/channel.ts
@@ -1,8 +1,8 @@
 /* eslint-disable max-classes-per-file */
 import { isEqual } from 'lodash'
 import { effectScope } from 'vue'
-import Manager from '@/useSubscription/models/manager'
-import Subscription from '@/useSubscription/models/subscription'
+import { SubscriptionManager } from '@/useSubscription/models/manager'
+import { Subscription } from '@/useSubscription/models/subscription'
 import {
   Action,
   ActionArguments,
@@ -38,10 +38,10 @@ class ChannelSignatureManager {
   }
 }
 
-export default class Channel<T extends Action = Action> {
+export class SubscriptionChannel<T extends Action = Action> {
   public readonly signature: ChannelSignature
 
-  private readonly manager: Manager
+  private readonly manager: SubscriptionManager
   private readonly action: T
   private readonly args: ActionArguments<T>
   private readonly subscriptions: Map<number, Subscription<T>> = new Map()
@@ -56,7 +56,7 @@ export default class Channel<T extends Action = Action> {
   private _error: unknown = null
   private _response: ActionResponse<T> | undefined = undefined
 
-  public constructor(manager: Manager, action: T, args: ActionArguments<T>) {
+  public constructor(manager: SubscriptionManager, action: T, args: ActionArguments<T>) {
     this.signature = ChannelSignatureManager.get(action, args)
     this.manager = manager
     this.action = action

--- a/src/useSubscription/models/index.ts
+++ b/src/useSubscription/models/index.ts
@@ -1,3 +1,3 @@
-export { default as channel } from './channel'
-export { default as manager } from './manager'
-export { default as subscription } from './subscription'
+export * from './channel'
+export * from './manager'
+export * from './subscription'

--- a/src/useSubscription/models/manager.ts
+++ b/src/useSubscription/models/manager.ts
@@ -1,5 +1,5 @@
-import Channel from '@/useSubscription/models/channel'
-import Subscription from '@/useSubscription/models/subscription'
+import { SubscriptionChannel } from '@/useSubscription/models/channel'
+import { Subscription } from '@/useSubscription/models/subscription'
 import {
   Action,
   ActionArguments,
@@ -8,8 +8,8 @@ import {
 import { SubscriptionOptions } from '@/useSubscription/types/subscription'
 import * as useSubscriptionDevtools from '@/useSubscription/useSubscriptionDevtools'
 
-export default class Manager {
-  private readonly channels: Map<ChannelSignature, Channel> = new Map()
+export class SubscriptionManager {
+  private readonly channels: Map<ChannelSignature, SubscriptionChannel> = new Map()
 
   public subscribe<T extends Action>(
     action: T,
@@ -48,11 +48,11 @@ export default class Manager {
   private getChannel<T extends Action>(
     action: T,
     args: ActionArguments<T>,
-  ): Channel<T> {
-    const channel = new Channel<T>(this, action, args)
+  ): SubscriptionChannel<T> {
+    const channel = new SubscriptionChannel<T>(this, action, args)
 
     if (this.channels.has(channel.signature)) {
-      return this.channels.get(channel.signature)! as Channel<T>
+      return this.channels.get(channel.signature)! as SubscriptionChannel<T>
     }
 
     this.addChannel(channel)
@@ -60,7 +60,7 @@ export default class Manager {
     return channel
   }
 
-  private addChannel(channel: Channel): void {
+  private addChannel(channel: SubscriptionChannel): void {
     this.channels.set(channel.signature, channel)
 
     useSubscriptionDevtools.addChannel(channel)

--- a/src/useSubscription/models/subscription.ts
+++ b/src/useSubscription/models/subscription.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-classes-per-file */
 import { ref, Ref, watch } from 'vue'
-import Channel from '@/useSubscription/models/channel'
+import { SubscriptionChannel } from '@/useSubscription/models/channel'
 import { Action, ActionResponse } from '@/useSubscription/types/action'
 import { SubscriptionOptions } from '@/useSubscription/types/subscription'
 import * as useSubscriptionDevtools from '@/useSubscription/useSubscriptionDevtools'
@@ -13,7 +13,7 @@ class SubscriptionIdManager {
   }
 }
 
-export default class Subscription<T extends Action> {
+export class Subscription<T extends Action> {
   public readonly id: number
   public readonly options: SubscriptionOptions
   public loading: Ref<boolean> = ref(false)
@@ -24,9 +24,9 @@ export default class Subscription<T extends Action> {
   public paused: Ref<boolean> = ref(false)
   public late: Ref<boolean> = ref(false)
 
-  private readonly channel: Channel<T>
+  private readonly channel: SubscriptionChannel<T>
 
-  public constructor(channel: Channel<T>, options: SubscriptionOptions) {
+  public constructor(channel: SubscriptionChannel<T>, options: SubscriptionOptions) {
     this.id = SubscriptionIdManager.get()
     this.channel = channel
     this.options = options

--- a/src/useSubscription/types/subscription.ts
+++ b/src/useSubscription/types/subscription.ts
@@ -1,6 +1,6 @@
 import { MaybeRef } from '@/types/maybe'
-import Manager from '@/useSubscription/models/manager'
-import Subscription from '@/useSubscription/models/subscription'
+import { SubscriptionManager } from '@/useSubscription/models/manager'
+import { Subscription } from '@/useSubscription/models/subscription'
 import { Action, ActionArguments, ActionParamsRequired, ActionResponse } from '@/useSubscription/types/action'
 
 export type SubscribeArguments<T extends Action> = ActionParamsRequired<T> extends never[]
@@ -10,7 +10,7 @@ export type SubscribeArguments<T extends Action> = ActionParamsRequired<T> exten
 export type SubscriptionOptions = {
   /** The maximum time in milliseconds before the subscription is considered stale and refreshes. Defaults to `Infinity` */
   interval?: number,
-  manager?: Manager,
+  manager?: SubscriptionManager,
   lifecycle?: 'component' | 'app',
   onError?: (error: unknown) => void,
 }

--- a/src/useSubscription/useSubscription.spec.ts
+++ b/src/useSubscription/useSubscription.spec.ts
@@ -2,7 +2,7 @@ import { render } from '@testing-library/vue'
 import { test, describe, it, expect, afterEach, vi } from 'vitest'
 import { computed, h, reactive, ref } from 'vue'
 import { useSubscription } from '@/useSubscription'
-import Manager from '@/useSubscription/models/manager'
+import { SubscriptionManager } from '@/useSubscription/models/manager'
 import { SubscriptionOptions, UseSubscription } from '@/useSubscription/types/subscription'
 import { timeout, uniqueSubscribe } from '@/utilities/tests'
 
@@ -120,7 +120,7 @@ describe('subscribe', () => {
   })
 
   it('executes the action once when two subscriptions are created', () => {
-    const manager = new Manager()
+    const manager = new SubscriptionManager()
     const action = vi.fn()
 
     useSubscription(action, [], { manager })
@@ -132,7 +132,7 @@ describe('subscribe', () => {
   it('calculates the poll interval correctly', () => {
     vi.useFakeTimers()
 
-    const manager = new Manager()
+    const manager = new SubscriptionManager()
     const action = vi.fn()
     const initialExecutions = 1
     const additionalExecutions = 3
@@ -150,7 +150,7 @@ describe('subscribe', () => {
   it('calculates the poll interval correctly when a subscription is unsubscribed', () => {
     vi.useFakeTimers()
 
-    const manager = new Manager()
+    const manager = new SubscriptionManager()
     const action = vi.fn()
     const initialExecutions = 1
     const additionalExecutions = 3
@@ -171,7 +171,7 @@ describe('subscribe', () => {
   it('stops polling when all subscriptions with interval unsubscribe', () => {
     vi.useFakeTimers()
 
-    const manager = new Manager()
+    const manager = new SubscriptionManager()
     const action = vi.fn()
     const minInterval = 10
     const maxInterval = 20
@@ -361,7 +361,7 @@ describe('subscribe', () => {
   })
 
   it('does not update subscription when unsubscribed', async () => {
-    const manager = new Manager()
+    const manager = new SubscriptionManager()
     let int = 0
 
     function action(): number {
@@ -481,7 +481,7 @@ describe('subscribe', () => {
       return 0
     }
 
-    const manager = new Manager()
+    const manager = new SubscriptionManager()
 
     useSubscription(action, [], { manager })
 
@@ -503,7 +503,7 @@ describe('subscribe', () => {
 
   it('correctly sets executed on additional subscriptions', async () => {
     const action = vi.fn()
-    const manager = new Manager()
+    const manager = new SubscriptionManager()
 
     useSubscription(action, [], { manager })
 
@@ -556,7 +556,7 @@ describe('subscribe', () => {
   })
 
   it('unsubscribes nested subscriptions automatically', () => {
-    const manager = new Manager()
+    const manager = new SubscriptionManager()
     const action = vi.fn()
     let childSubscription: UseSubscription<typeof action>
 
@@ -573,7 +573,7 @@ describe('subscribe', () => {
 
   it('unsubscribes nested subscriptions when changing args', async () => {
     const number = ref(0)
-    const manager = new Manager()
+    const manager = new SubscriptionManager()
     const action = vi.fn()
     let childSubscription: UseSubscription<typeof action>
 
@@ -593,7 +593,7 @@ describe('subscribe', () => {
 
   it('it refreshes nested subscriptions when calling refresh', async () => {
     const action = vi.fn()
-    const manager = new Manager()
+    const manager = new SubscriptionManager()
     const subscription = useSubscription((): void => {
       useSubscription(action, [], { manager })
     }, [], { manager })
@@ -649,7 +649,7 @@ describe('subscribe', () => {
     vi.useFakeTimers()
 
     const interval = 1000
-    const manager = new Manager()
+    const manager = new SubscriptionManager()
     const action = vi.fn()
 
     const subscription = useSubscription(action, [], { manager, interval })

--- a/src/useSubscription/useSubscription.ts
+++ b/src/useSubscription/useSubscription.ts
@@ -1,5 +1,5 @@
 import { reactive, unref } from 'vue'
-import Manager from '@/useSubscription/models/manager'
+import { SubscriptionManager } from '@/useSubscription/models'
 import { Action, ActionArguments } from '@/useSubscription/types/action'
 import { SubscribeArguments, UseSubscription } from '@/useSubscription/types/subscription'
 import { mapSubscription } from '@/useSubscription/utilities/subscriptions'
@@ -7,7 +7,7 @@ import { getValidWatchSource } from '@/utilities/getValidWatchSource'
 import { tryOnScopeDispose } from '@/utilities/tryOnScopeDispose'
 import { uniqueValueWatcher } from '@/utilities/uniqueValueWatcher'
 
-export const defaultSubscriptionManager = new Manager()
+export const defaultSubscriptionManager = new SubscriptionManager()
 
 /**
  * The `useSubscription` composition manages data sharing across components. Multiple components can subscribe to an `action` (any method or function) and share the response value.

--- a/src/useSubscription/useSubscriptionDevtools.ts
+++ b/src/useSubscription/useSubscriptionDevtools.ts
@@ -7,7 +7,7 @@ import type {
   ExtractSettingsTypes
 } from '@vue/devtools-api'
 import { ComponentInternalInstance, getCurrentInstance, nextTick } from 'vue'
-import Channel from '@/useSubscription/models/channel'
+import { SubscriptionChannel } from '@/useSubscription/models/channel'
 
 function throttle(fn: () => void, wait: number): () => void {
   let isThrottled = false
@@ -53,8 +53,8 @@ export const SUBSCRIPTION_DEVTOOLS_SETTINGS = {
 
 export type SubscriptionDevtoolsSettings = ExtractSettingsTypes<typeof SUBSCRIPTION_DEVTOOLS_SETTINGS>
 
-const channelNodes: Map<Channel['signature'], { node: CustomInspectorNode, channel: Channel }> = new Map()
-const subscribedComponents: Map<Channel['signature'], Map<number, ComponentInternalInstance | null>> = new Map()
+const channelNodes: Map<SubscriptionChannel['signature'], { node: CustomInspectorNode, channel: SubscriptionChannel }> = new Map()
+const subscribedComponents: Map<SubscriptionChannel['signature'], Map<number, ComponentInternalInstance | null>> = new Map()
 let API: DevtoolsPluginApi<Record<string, unknown>> | null = null
 
 export function init(api: DevtoolsPluginApi<SubscriptionDevtoolsSettings>): void {
@@ -110,7 +110,7 @@ const refresh: () => void = throttle(() => {
   }, 100)
 }, 200)
 
-export function addChannel(channel: Channel): void {
+export function addChannel(channel: SubscriptionChannel): void {
   if (!initialized()) {
     return
   }
@@ -124,7 +124,7 @@ export type UpdateChannelEventTypes = 'Loading' | 'Error' | 'Executed' | 'Respon
 type UpdateChannelEvent = {
   [K in UpdateChannelEventTypes]: CreateSubscriptionDevtoolsTimelineEvent<K, EventTypeToDataMap[K]>
 }[UpdateChannelEventTypes]
-export function updateChannel(channel: Channel, event: UpdateChannelEvent): void {
+export function updateChannel(channel: SubscriptionChannel, event: UpdateChannelEvent): void {
   if (!initialized()) {
     return
   }
@@ -134,7 +134,7 @@ export function updateChannel(channel: Channel, event: UpdateChannelEvent): void
   refresh()
 }
 
-export function removeChannel(channel: Channel): void {
+export function removeChannel(channel: SubscriptionChannel): void {
   if (!initialized()) {
     return
   }
@@ -144,7 +144,7 @@ export function removeChannel(channel: Channel): void {
   refresh()
 }
 
-export function registerChannelSubscription(channel: Channel, subscriptionId: number): void {
+export function registerChannelSubscription(channel: SubscriptionChannel, subscriptionId: number): void {
   if (!initialized()) {
     return
   }
@@ -158,7 +158,7 @@ export function registerChannelSubscription(channel: Channel, subscriptionId: nu
   refresh()
 }
 
-export function removeChannelSubscription(channel: Channel, subscriptionId: number): void {
+export function removeChannelSubscription(channel: SubscriptionChannel, subscriptionId: number): void {
   if (!initialized()) {
     return
   }
@@ -178,7 +178,7 @@ type SubscriptionsInspectorState = CustomInspectorState & {
 }
 
 async function getCustomInspectorState(nodeId: string): Promise<SubscriptionsInspectorState> {
-  const { channel } = channelNodes.get(nodeId as Channel['signature']) ?? {}
+  const { channel } = channelNodes.get(nodeId as SubscriptionChannel['signature']) ?? {}
   if (!channel) {
     return { 'Error': [{ key: 'message', value: 'Channel not found.' }], 'State': [], 'Subscribed Components': [] }
   }
@@ -212,17 +212,17 @@ type CreateSubscriptionDevtoolsTimelineEvent<TEvent extends string, TData> = Omi
 }
 
 type EventTypeToDataMap = {
-  'Channel created': { channel: Channel, action: string },
-  'Channel removed': { channel: Channel, action: string },
-  'Subscription created': { channel: Channel, action: string, subscriptionId: number },
-  'Subscription removed': { channel: Channel, action: string, subscriptionId: number },
-  'Loading': { channel: Channel, action: string, loading: boolean },
-  'Error': { channel: Channel, action: string, error: unknown },
-  'Executed': { channel: Channel, action: string, executed: boolean },
-  'Response': { channel: Channel, action: string, response: unknown },
-  'Refresh': { channel: Channel, action: string },
-  'Paused': { channel: Channel, action: string, paused: boolean },
-  'Late': { channel: Channel, action: string, late: boolean },
+  'Channel created': { channel: SubscriptionChannel, action: string },
+  'Channel removed': { channel: SubscriptionChannel, action: string },
+  'Subscription created': { channel: SubscriptionChannel, action: string, subscriptionId: number },
+  'Subscription removed': { channel: SubscriptionChannel, action: string, subscriptionId: number },
+  'Loading': { channel: SubscriptionChannel, action: string, loading: boolean },
+  'Error': { channel: SubscriptionChannel, action: string, error: unknown },
+  'Executed': { channel: SubscriptionChannel, action: string, executed: boolean },
+  'Response': { channel: SubscriptionChannel, action: string, response: unknown },
+  'Refresh': { channel: SubscriptionChannel, action: string },
+  'Paused': { channel: SubscriptionChannel, action: string, paused: boolean },
+  'Late': { channel: SubscriptionChannel, action: string, late: boolean },
 }
 
 type SubscriptionDevtoolsTimelineEvent = {
@@ -239,7 +239,7 @@ function addTimelineEvent(event: SubscriptionDevtoolsTimelineEvent): void {
   })
 }
 
-function mapChannelToInspectorNode(channel: Channel): CustomInspectorNode {
+function mapChannelToInspectorNode(channel: SubscriptionChannel): CustomInspectorNode {
   return {
     id: channel.signature,
     label: `${channel.actionName} ${channel.signature}`,

--- a/src/useSubscription/utilities/subscriptions.ts
+++ b/src/useSubscription/utilities/subscriptions.ts
@@ -1,5 +1,5 @@
 import { reactive } from 'vue'
-import Subscription from '@/useSubscription/models/subscription'
+import { Subscription } from '@/useSubscription/models'
 import { Action } from '@/useSubscription/types/action'
 import { MappedSubscription, SubscriptionPromise } from '@/useSubscription/types/subscription'
 

--- a/src/utilities/tests.ts
+++ b/src/utilities/tests.ts
@@ -1,6 +1,6 @@
 import { computed, unref } from 'vue'
 import { useSubscription } from '@/useSubscription'
-import Manager from '@/useSubscription/models/manager'
+import { SubscriptionManager } from '@/useSubscription/models/manager'
 import { Action } from '@/useSubscription/types/action'
 import { SubscribeArguments, UseSubscription } from '@/useSubscription/types/subscription'
 
@@ -14,7 +14,7 @@ export function uniqueSubscribe<T extends Action>(...[action, args, optionsArg =
 
     return {
       ...options,
-      manager: new Manager(),
+      manager: new SubscriptionManager(),
     }
   })
 


### PR DESCRIPTION
# Description
The models for subscriptions were exported as lowercase which doesn't seem right for classes. So as a little cleanup I did the following
- Renamed `Manager` to `SubscriptionManager`
- Renamed `Channel` to `SubscriptionChannel`
- Removed default exports for `Subscription`, `SubscriptionChannel, and `SubscriptionManager
- Updated imports across the codebase