### PR TITLE
Subscriptions: Add the ability to refresh a channel without creating a subscription

### DIFF
--- a/src/useSubscription/models/manager.spec.ts
+++ b/src/useSubscription/models/manager.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test, vi } from 'vitest'
+import { SubscriptionManager } from '@/useSubscription/models/manager'
+
+test('refresh only calls the action if an channel exists', async () => {
+  const action = vi.fn()
+  const manager = new SubscriptionManager()
+
+  manager.refresh(action, [])
+
+  expect(action).toBeCalledTimes(0)
+
+  const subscription = await manager.subscribe(action, [], {}).promise()
+
+  expect(action).toBeCalledTimes(1)
+
+  manager.refresh(action, [])
+
+  expect(action).toBeCalledTimes(2)
+
+  subscription.unsubscribe()
+
+  manager.refresh(action, [])
+
+  expect(action).toBeCalledTimes(2)
+})

--- a/src/useSubscription/models/manager.ts
+++ b/src/useSubscription/models/manager.ts
@@ -36,6 +36,15 @@ export class SubscriptionManager {
     }
   }
 
+  public refresh<T extends Action>(
+    action: T,
+    args: ActionArguments<T>,
+  ): void {
+    const { signature } = new SubscriptionChannel<T>(this, action, args)
+
+    this.channels.get(signature)?.refresh()
+  }
+
   public deleteChannel(signature: ChannelSignature): void {
     const channel = this.channels.get(signature)
     if (channel) {

--- a/src/useSubscription/utilities/index.ts
+++ b/src/useSubscription/utilities/index.ts
@@ -1,3 +1,4 @@
 export * from './createActions'
 export * from './reactivity'
 export * from './subscriptions'
+export * from './refresh'

--- a/src/useSubscription/utilities/refresh.ts
+++ b/src/useSubscription/utilities/refresh.ts
@@ -1,0 +1,11 @@
+import { SubscriptionManager } from '@/useSubscription/models'
+import { Action, ActionArguments } from '@/useSubscription/types/action'
+import { defaultSubscriptionManager } from '@/useSubscription/useSubscription'
+
+export function refreshChannel<T extends Action>(
+  action: T,
+  args: ActionArguments<T>,
+  manager: SubscriptionManager = defaultSubscriptionManager,
+): void {
+  return manager.refresh(action, args)
+}


### PR DESCRIPTION
# Description
Introduced a `refresh` method on `SubscriptionManager` and a `refreshChannel` utility that wraps it. Calling refresh will refresh a channel directly without creating a new subscription. If not channel exists its a noop. 