### PR TITLE
Add maxRefreshRate to channel refresh utilities

### DIFF
--- a/src/useSubscription/models/channel.ts
+++ b/src/useSubscription/models/channel.ts
@@ -47,7 +47,7 @@ export class SubscriptionChannel<T extends Action = Action> {
   private readonly subscriptions: Map<number, Subscription<T>> = new Map()
   private scope = effectScope()
   private timer: ReturnType<typeof setInterval> | null = null
-  private lastExecution: number = 0
+  private _lastExecution: number = 0
   private _late: boolean = false
   private _paused: boolean = false
   private _loading: boolean = false
@@ -61,6 +61,10 @@ export class SubscriptionChannel<T extends Action = Action> {
     this.manager = manager
     this.action = action
     this.args = args
+  }
+
+  public get lastExecution(): number {
+    return this._lastExecution
   }
 
   public get actionName(): string {
@@ -245,7 +249,7 @@ export class SubscriptionChannel<T extends Action = Action> {
     const args = unrefArgs(this.args)
 
     this.loading = true
-    this.lastExecution = Date.now()
+    this._lastExecution = Date.now()
 
     this.setInterval()
 

--- a/src/useSubscription/models/manager.spec.ts
+++ b/src/useSubscription/models/manager.spec.ts
@@ -25,6 +25,7 @@ test('refresh only calls the action if an channel exists', async () => {
 })
 
 test('refresh does not execute if maxRefreshRate has not been exceeded', async () => {
+  vi.useFakeTimers()
   const action = vi.fn()
   const manager = new SubscriptionManager()
   const maxRefreshRate = 50
@@ -37,5 +38,9 @@ test('refresh does not execute if maxRefreshRate has not been exceeded', async (
   manager.refresh(action, [], { maxRefreshRate })
   manager.refresh(action, [], { maxRefreshRate })
 
-  expect(action).toBeCalledTimes(1)
+  vi.advanceTimersByTime(maxRefreshRate)
+
+  manager.refresh(action, [], { maxRefreshRate })
+
+  expect(action).toBeCalledTimes(2)
 })

--- a/src/useSubscription/models/manager.spec.ts
+++ b/src/useSubscription/models/manager.spec.ts
@@ -23,3 +23,19 @@ test('refresh only calls the action if an channel exists', async () => {
 
   expect(action).toBeCalledTimes(2)
 })
+
+test('refresh does not execute if maxRefreshRate has not been exceeded', async () => {
+  const action = vi.fn()
+  const manager = new SubscriptionManager()
+  const maxRefreshRate = 50
+
+  await manager.subscribe(action, [], {}).promise()
+
+  expect(action).toBeCalledTimes(1)
+
+  manager.refresh(action, [], { maxRefreshRate })
+  manager.refresh(action, [], { maxRefreshRate })
+  manager.refresh(action, [], { maxRefreshRate })
+
+  expect(action).toBeCalledTimes(1)
+})

--- a/src/useSubscription/models/manager.ts
+++ b/src/useSubscription/models/manager.ts
@@ -5,6 +5,7 @@ import {
   ActionArguments,
   ChannelSignature
 } from '@/useSubscription/types/action'
+import { ManagerRefreshChannelOptions } from '@/useSubscription/types/channels'
 import { SubscriptionOptions } from '@/useSubscription/types/subscription'
 import * as useSubscriptionDevtools from '@/useSubscription/useSubscriptionDevtools'
 
@@ -39,10 +40,22 @@ export class SubscriptionManager {
   public refresh<T extends Action>(
     action: T,
     args: ActionArguments<T>,
+    options?: ManagerRefreshChannelOptions,
   ): void {
     const { signature } = new SubscriptionChannel<T>(this, action, args)
+    const channel = this.channels.get(signature)
 
-    this.channels.get(signature)?.refresh()
+    if (!channel) {
+      return
+    }
+
+    const maxRefreshRate = options?.maxRefreshRate ?? 0
+
+    if (channel.lastExecution + maxRefreshRate > Date.now()) {
+      return
+    }
+
+    channel.refresh()
   }
 
   public deleteChannel(signature: ChannelSignature): void {

--- a/src/useSubscription/types/channels.ts
+++ b/src/useSubscription/types/channels.ts
@@ -1,0 +1,8 @@
+import { SubscriptionManager } from '@/useSubscription/models'
+
+export type RefreshChannelOptions = {
+  maxRefreshRate?: number,
+  manager?: SubscriptionManager,
+}
+
+export type ManagerRefreshChannelOptions = Omit<RefreshChannelOptions, 'manager'>

--- a/src/useSubscription/types/index.ts
+++ b/src/useSubscription/types/index.ts
@@ -1,3 +1,4 @@
 export * from './action'
+export * from './channels'
 export * from './subscription'
 export * from './utilities'

--- a/src/useSubscription/utilities/refresh.ts
+++ b/src/useSubscription/utilities/refresh.ts
@@ -1,11 +1,13 @@
-import { SubscriptionManager } from '@/useSubscription/models'
 import { Action, ActionArguments } from '@/useSubscription/types/action'
+import { RefreshChannelOptions } from '@/useSubscription/types/channels'
 import { defaultSubscriptionManager } from '@/useSubscription/useSubscription'
 
 export function refreshChannel<T extends Action>(
   action: T,
   args: ActionArguments<T>,
-  manager: SubscriptionManager = defaultSubscriptionManager,
+  options?: RefreshChannelOptions,
 ): void {
-  return manager.refresh(action, args)
+  const manager = options?.manager ?? defaultSubscriptionManager
+
+  return manager.refresh(action, args, options)
 }


### PR DESCRIPTION
# Description
Allows refreshing a channel via `manager.refresh` or the `refreshChannel` utility to factor in the last execution time. By specifying `maxRefreshRate` as a number of milliseconds, the refresh will be a noop if the channel was executed within the specified rate. 