### PR TITLE
Add `maxRefreshRate` directly to `Channel` and `Subscription` classes

### DIFF
--- a/src/useSubscription/models/manager.ts
+++ b/src/useSubscription/models/manager.ts
@@ -5,7 +5,7 @@ import {
   ActionArguments,
   ChannelSignature
 } from '@/useSubscription/types/action'
-import { ManagerRefreshChannelOptions } from '@/useSubscription/types/channels'
+import { RefreshChannelOptions } from '@/useSubscription/types/channels'
 import { SubscriptionOptions } from '@/useSubscription/types/subscription'
 import * as useSubscriptionDevtools from '@/useSubscription/useSubscriptionDevtools'
 
@@ -40,7 +40,7 @@ export class SubscriptionManager {
   public refresh<T extends Action>(
     action: T,
     args: ActionArguments<T>,
-    options?: ManagerRefreshChannelOptions,
+    options?: RefreshChannelOptions,
   ): void {
     const { signature } = new SubscriptionChannel<T>(this, action, args)
     const channel = this.channels.get(signature)
@@ -49,13 +49,7 @@ export class SubscriptionManager {
       return
     }
 
-    const maxRefreshRate = options?.maxRefreshRate ?? 0
-
-    if (channel.lastExecution + maxRefreshRate > Date.now()) {
-      return
-    }
-
-    channel.refresh()
+    channel.refresh(options)
   }
 
   public deleteChannel(signature: ChannelSignature): void {

--- a/src/useSubscription/models/subscription.ts
+++ b/src/useSubscription/models/subscription.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-classes-per-file */
 import { ref, Ref, watch } from 'vue'
 import { SubscriptionChannel } from '@/useSubscription/models/channel'
+import { RefreshChannelOptions } from '@/useSubscription/types'
 import { Action, ActionResponse } from '@/useSubscription/types/action'
 import { SubscriptionOptions } from '@/useSubscription/types/subscription'
 import * as useSubscriptionDevtools from '@/useSubscription/useSubscriptionDevtools'
@@ -38,8 +39,8 @@ export class Subscription<T extends Action> {
     this.executed.value = channel.executed
   }
 
-  public async refresh(): Promise<void> {
-    await this.channel.refresh()
+  public async refresh(options?: RefreshChannelOptions): Promise<void> {
+    await this.channel.refresh(options)
   }
 
   public unsubscribe(): void {

--- a/src/useSubscription/types/channels.ts
+++ b/src/useSubscription/types/channels.ts
@@ -1,8 +1,3 @@
-import { SubscriptionManager } from '@/useSubscription/models'
-
 export type RefreshChannelOptions = {
   maxRefreshRate?: number,
-  manager?: SubscriptionManager,
 }
-
-export type ManagerRefreshChannelOptions = Omit<RefreshChannelOptions, 'manager'>

--- a/src/useSubscription/utilities/refresh.ts
+++ b/src/useSubscription/utilities/refresh.ts
@@ -1,11 +1,13 @@
+import { SubscriptionManager } from '@/useSubscription/models/manager'
 import { Action, ActionArguments } from '@/useSubscription/types/action'
 import { RefreshChannelOptions } from '@/useSubscription/types/channels'
 import { defaultSubscriptionManager } from '@/useSubscription/useSubscription'
 
+
 export function refreshChannel<T extends Action>(
   action: T,
   args: ActionArguments<T>,
-  options?: RefreshChannelOptions,
+  options?: RefreshChannelOptions & { manager?: SubscriptionManager },
 ): void {
   const manager = options?.manager ?? defaultSubscriptionManager
 


### PR DESCRIPTION
# Description
Builds on https://github.com/PrefectHQ/vue-compositions/pull/397 by adding `maxRefreshRate` logic directly to the channel's refresh method itself rather than using it only in `manager.refresh`. Also exposes the option in `subscription.refresh` so you can use it on existing subscriptions