### PR TITLE
Bugfix: Relative import in `useClickOutside`

### DIFF
--- a/src/useClickOutside/useClickOutside.ts
+++ b/src/useClickOutside/useClickOutside.ts
@@ -1,6 +1,6 @@
 import { onScopeDispose } from 'vue'
-import { useGlobalEventListener } from '..'
 import { MaybeRefOrGetter } from '@/types/maybe'
+import { useGlobalEventListener } from '@/useGlobalEventListener'
 import { toValue } from '@/utilities/vue'
 
 type ClickOutsideEntry = {


### PR DESCRIPTION
I _think_ this is what's breaking the 1.11.1 build.