### PR TITLE
Remove some 3.3. shims

### DIFF
--- a/src/types/maybe.ts
+++ b/src/types/maybe.ts
@@ -1,7 +1,5 @@
-import { Ref, UnwrapRef } from 'vue'
+import { UnwrapRef } from 'vue'
 
 export type MaybePromise<T = unknown> = T | Promise<T>
-export type MaybeRef<T = unknown> = T | Ref<T>
 export type MaybeUnwrapRef<T = unknown> = T | UnwrapRef<T>
-export type MaybeRefOrGetter<T = unknown> = MaybeRef<T> | (() => T)
 export type MaybeArray<T = unknown> = T | T[]

--- a/src/useBoolean/useBoolean.ts
+++ b/src/useBoolean/useBoolean.ts
@@ -1,5 +1,4 @@
-import { ref, Ref } from 'vue'
-import { MaybeRef } from '@/types/maybe'
+import { ref, Ref, MaybeRef } from 'vue'
 
 type UseBoolean = {
   value: Ref<boolean>,

--- a/src/useClickOutside/useClickOutside.ts
+++ b/src/useClickOutside/useClickOutside.ts
@@ -1,5 +1,4 @@
-import { onScopeDispose, toValue } from 'vue'
-import { MaybeRefOrGetter } from '@/types/maybe'
+import { MaybeRefOrGetter, onScopeDispose, toValue } from 'vue'
 import { useGlobalEventListener } from '@/useGlobalEventListener'
 
 type ClickOutsideEntry = {

--- a/src/useClickOutside/useClickOutside.ts
+++ b/src/useClickOutside/useClickOutside.ts
@@ -1,7 +1,6 @@
-import { onScopeDispose } from 'vue'
+import { onScopeDispose, toValue } from 'vue'
 import { MaybeRefOrGetter } from '@/types/maybe'
 import { useGlobalEventListener } from '@/useGlobalEventListener'
-import { toValue } from '@/utilities/vue'
 
 type ClickOutsideEntry = {
   element: MaybeRefOrGetter<Element>,

--- a/src/useEventListener/useEventListener.ts
+++ b/src/useEventListener/useEventListener.ts
@@ -1,7 +1,6 @@
-import { ref, watch } from 'vue'
+import { ref, watch, toValue } from 'vue'
 import { MaybeRefOrGetter } from '@/types/maybe'
 import { tryOnScopeDispose } from '@/utilities/tryOnScopeDispose'
-import { toValue } from '@/utilities/vue'
 
 export type UseEventListener = {
   add: () => void,

--- a/src/useEventListener/useEventListener.ts
+++ b/src/useEventListener/useEventListener.ts
@@ -1,5 +1,4 @@
-import { ref, watch, toValue } from 'vue'
-import { MaybeRefOrGetter } from '@/types/maybe'
+import { ref, watch, toValue, MaybeRefOrGetter } from 'vue'
 import { tryOnScopeDispose } from '@/utilities/tryOnScopeDispose'
 
 export type UseEventListener = {

--- a/src/useIntersectionObserver/useIntersectionObserver.ts
+++ b/src/useIntersectionObserver/useIntersectionObserver.ts
@@ -1,5 +1,4 @@
-import { onMounted, onUnmounted, ref, Ref, unref, watch, toValue } from 'vue'
-import { MaybeRef, MaybeRefOrGetter } from '@/types/maybe'
+import { onMounted, onUnmounted, ref, Ref, unref, watch, toValue, MaybeRef, MaybeRefOrGetter } from 'vue'
 
 export type UseIntersectionObserverResponse = {
   observe: (element: MaybeRefOrGetter<HTMLElement | undefined>) => void,

--- a/src/useIntersectionObserver/useIntersectionObserver.ts
+++ b/src/useIntersectionObserver/useIntersectionObserver.ts
@@ -1,6 +1,5 @@
-import { onMounted, onUnmounted, ref, Ref, unref, watch } from 'vue'
+import { onMounted, onUnmounted, ref, Ref, unref, watch, toValue } from 'vue'
 import { MaybeRef, MaybeRefOrGetter } from '@/types/maybe'
-import { toValue } from '@/utilities/vue'
 
 export type UseIntersectionObserverResponse = {
   observe: (element: MaybeRefOrGetter<HTMLElement | undefined>) => void,

--- a/src/useIsSame/useIsSame.ts
+++ b/src/useIsSame/useIsSame.ts
@@ -1,5 +1,4 @@
-import { computed, ComputedRef, ref } from 'vue'
-import { MaybeRef } from '@/types/maybe'
+import { computed, ComputedRef, ref, MaybeRef } from 'vue'
 import { isSame } from '@/utilities/isSame'
 
 export function useIsSame(valueA: MaybeRef, valueB: MaybeRef): ComputedRef<boolean> {

--- a/src/useKeyDown/useKeyDown.ts
+++ b/src/useKeyDown/useKeyDown.ts
@@ -1,5 +1,5 @@
-import { ComputedRef, computed, reactive, unref } from 'vue'
-import { MaybeArray, MaybeRef } from '@/types/maybe'
+import { ComputedRef, computed, reactive, unref, MaybeRef } from 'vue'
+import { MaybeArray } from '@/types/maybe'
 import { asArray } from '@/utilities/arrays'
 import { tryOnScopeDispose } from '@/utilities/tryOnScopeDispose'
 

--- a/src/useNow/useNow.ts
+++ b/src/useNow/useNow.ts
@@ -1,5 +1,4 @@
-import { ref, Ref } from 'vue'
-import { MaybeRef } from '@/types/maybe'
+import { ref, Ref, MaybeRef } from 'vue'
 import { tryOnScopeDispose } from '@/utilities/tryOnScopeDispose'
 
 export type UseNow = {

--- a/src/usePositionStickyObserver/usePositionStickyObserver.ts
+++ b/src/usePositionStickyObserver/usePositionStickyObserver.ts
@@ -1,5 +1,4 @@
-import { Ref, computed, ref, watch, toRef, toValue } from 'vue'
-import { MaybeRefOrGetter } from '@/types/maybe'
+import { Ref, computed, ref, watch, toRef, toValue, MaybeRefOrGetter } from 'vue'
 import { useIntersectionObserver } from '@/useIntersectionObserver'
 
 export type UsePositionStickyObserverResponse = {

--- a/src/usePositionStickyObserver/usePositionStickyObserver.ts
+++ b/src/usePositionStickyObserver/usePositionStickyObserver.ts
@@ -1,7 +1,6 @@
-import { Ref, computed, ref, watch } from 'vue'
+import { Ref, computed, ref, watch, toRef, toValue } from 'vue'
 import { MaybeRefOrGetter } from '@/types/maybe'
 import { useIntersectionObserver } from '@/useIntersectionObserver'
-import { toValue } from '@/utilities/vue'
 
 export type UsePositionStickyObserverResponse = {
   stuck: Ref<boolean>,
@@ -21,7 +20,7 @@ export function usePositionStickyObserver(
   element: MaybeRefOrGetter<HTMLElement | undefined>,
   options?: MaybeRefOrGetter<UsePositionStickyObserverOptions>,
 ): UsePositionStickyObserverResponse {
-  const elementRef = computed(() => toValue(element))
+  const elementRef = toRef(element)
   const stuck = ref(false)
 
   const observerOptions = computed(() => {

--- a/src/useScrollLinking/useScrollLinking.ts
+++ b/src/useScrollLinking/useScrollLinking.ts
@@ -1,5 +1,4 @@
-import { onMounted, onUnmounted, ref, Ref } from 'vue'
-import { MaybeRef } from '@/types/maybe'
+import { onMounted, onUnmounted, ref, Ref, MaybeRef } from 'vue'
 
 type DisconnectScrollLink = () => void
 type UseScrollLinking = {

--- a/src/useSubscription/types/subscription.ts
+++ b/src/useSubscription/types/subscription.ts
@@ -1,4 +1,4 @@
-import { MaybeRef } from '@/types/maybe'
+import { MaybeRef } from 'vue'
 import { SubscriptionManager } from '@/useSubscription/models/manager'
 import { Subscription } from '@/useSubscription/models/subscription'
 import { Action, ActionArguments, ActionParamsRequired, ActionResponse } from '@/useSubscription/types/action'

--- a/src/useSubscription/useSubscriptionWithDependencies.ts
+++ b/src/useSubscription/useSubscriptionWithDependencies.ts
@@ -1,6 +1,5 @@
 import isEqual from 'lodash.isequal'
-import { reactive, ref, Ref, toRaw, watch } from 'vue'
-import { MaybeRef } from '@/types/maybe'
+import { reactive, ref, Ref, toRaw, watch, MaybeRef } from 'vue'
 import { Action, SubscriptionOptions, UseSubscription, ActionArguments, MappedSubscription } from '@/useSubscription/types'
 import { useSubscription } from '@/useSubscription/useSubscription'
 

--- a/src/useValidation/useValidation.ts
+++ b/src/useValidation/useValidation.ts
@@ -1,6 +1,6 @@
-import { computed, onMounted, onUnmounted, reactive, ref, ToRefs, watch, unref, Ref, WatchStopHandle, toRef } from 'vue'
+import { computed, onMounted, onUnmounted, reactive, ref, ToRefs, watch, unref, Ref, MaybeRef, MaybeRefOrGetter, WatchStopHandle, toRef } from 'vue'
 import { NoInfer } from '@/types/generics'
-import { MaybeArray, MaybePromise, MaybeRefOrGetter, MaybeRef } from '@/types/maybe'
+import { MaybeArray, MaybePromise } from '@/types/maybe'
 import { isValidationAbortedError } from '@/useValidation/ValidationAbortedError'
 import { ValidationRuleExecutor } from '@/useValidation/ValidationExecutor'
 import { ValidationObserverUnregister, VALIDATION_OBSERVER_INJECTION_KEY } from '@/useValidationObserver/useValidationObserver'

--- a/src/useVisibilityObserver/useVisibilityObserver.ts
+++ b/src/useVisibilityObserver/useVisibilityObserver.ts
@@ -1,5 +1,4 @@
-import { computed, onMounted, ref, Ref } from 'vue'
-import { MaybeRef } from '@/types/maybe'
+import { computed, onMounted, ref, Ref, MaybeRef } from 'vue'
 import { useIntersectionObserver, UseIntersectionObserverOptions } from '@/useIntersectionObserver'
 
 export type UseVisibilityObserverResponse = {

--- a/src/utilities/vue.ts
+++ b/src/utilities/vue.ts
@@ -1,8 +1,0 @@
-import { unref } from 'vue'
-import { MaybeRefOrGetter } from '@/types/maybe'
-import { isFunction } from '@/utilities/functions'
-
-// temp shim for Vue 3.3^ function
-export function toValue<T>(source: MaybeRefOrGetter<T>): T {
-  return isFunction(source) ? source() : unref(source)
-}


### PR DESCRIPTION
Now that vue-comp has a peer dependency of vue@^3.3.0, we can remove:
- toValue
- MaybeRef
- MaybeRefOrGetter

as they're all built-in to vue now.