### PR TITLE
Bugfix: `useRouteQueryParam` over-eager reactive updates

### DIFF
--- a/src/useRouteQueryParam/formats/RouteParam.ts
+++ b/src/useRouteQueryParam/formats/RouteParam.ts
@@ -58,7 +58,7 @@ export abstract class RouteParam<T> {
   }
 
   public set(query: LocationQuery, value: T | T[] | undefined): void {
-    if (value === undefined) {
+    if (value === undefined || value === null) {
       delete query[this.key]
       return
     }

--- a/src/useRouteQueryParam/formats/RouteParam.ts
+++ b/src/useRouteQueryParam/formats/RouteParam.ts
@@ -58,7 +58,7 @@ export abstract class RouteParam<T> {
   }
 
   public set(query: LocationQuery, value: T | T[] | undefined): void {
-    if (value === undefined || value === null) {
+    if (value === undefined) {
       delete query[this.key]
       return
     }

--- a/src/useRouteQueryParam/useRouteQueryParam.ts
+++ b/src/useRouteQueryParam/useRouteQueryParam.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/unified-signatures */
 
 import isEqual from 'lodash.isequal'
-import { computed, ref, Ref, watch } from 'vue'
+import { computed, Ref } from 'vue'
 import { NoInfer } from '@/types/generics'
 import { MaybeArray } from '@/types/maybe'
 import { useRouteQuery } from '@/useRouteQuery/useRouteQuery'
@@ -44,21 +44,16 @@ export function useRouteQueryParam(key: string, formatterOrDefaultValue?: RouteP
   const [formatter] = asArray(formatterOrDefaultValue)
   const defaultValue = maybeDefaultValue
   const format = new formatter({ key, defaultValue, multiple })
-  const internalValue = ref(format.get(query))
-
-  watch(() => query[key], () => {
-    const newInternalValue = format.get(query)
-
-    if (isEqual(internalValue.value, newInternalValue)) {
-      return
-    }
-
-    internalValue.value = newInternalValue
-  })
 
   return computed({
-    get() {
-      return internalValue.value
+    get(oldValue) {
+      const value = format.get(query)
+
+      if (isEqual(value, oldValue)) {
+        return oldValue
+      }
+
+      return value
     },
     set(value) {
       format.set(query, value)

--- a/src/useRouteQueryParam/useRouteQueryParam.ts
+++ b/src/useRouteQueryParam/useRouteQueryParam.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/unified-signatures */
 
-import { computed, Ref } from 'vue'
+import isEqual from 'lodash.isequal'
+import { computed, ref, Ref, watch } from 'vue'
 import { NoInfer } from '@/types/generics'
 import { MaybeArray } from '@/types/maybe'
 import { useRouteQuery } from '@/useRouteQuery/useRouteQuery'
@@ -43,11 +44,21 @@ export function useRouteQueryParam(key: string, formatterOrDefaultValue?: RouteP
   const [formatter] = asArray(formatterOrDefaultValue)
   const defaultValue = maybeDefaultValue
   const format = new formatter({ key, defaultValue, multiple })
+  const internalValue = ref(format.get(query))
 
+  watch(() => query[key], () => {
+    const newInternalValue = format.get(query)
+
+    if (isEqual(internalValue.value, newInternalValue)) {
+      return
+    }
+
+    internalValue.value = newInternalValue
+  })
 
   return computed({
     get() {
-      return format.get(query)
+      return internalValue.value
     },
     set(value) {
       format.set(query, value)


### PR DESCRIPTION
This PR introduces a new intermediary watcher for `useRouteQueryParam`. This watcher performs the task of watching the query object for the passed key and updating an internal reactive value instead of passing back a computed getter that reacts to the entire reactive query object. This fixes an issue where updating any query param caused all query params to rerun their reactive getters even if they were unchanged. 