### PR TITLE
Prevent `useStorage` from immediately saving the default value 

### DIFF
--- a/src/useStorage/useStorage.ts
+++ b/src/useStorage/useStorage.ts
@@ -1,5 +1,4 @@
-/* eslint-disable no-redeclare */
-import { ref, Ref, UnwrapRef, watchEffect } from 'vue'
+import { ref, Ref, UnwrapRef, watch } from 'vue'
 import { StorageManager, StorageType } from '@/useStorage/storage'
 
 type UseStorage<T> = {
@@ -34,13 +33,13 @@ export function useStorage<T>(type: StorageType, key: string, defaultValue: T | 
     data.value = value
   }
 
-  watchEffect(() => {
+  watch(data, value => {
     if (stopped) {
       console.warn(`Storage for key ${key} as been removed and cannot be updated`)
       return
     }
 
-    storage.set(key, data.value)
+    storage.set(key, value)
   })
 
   return {


### PR DESCRIPTION
# Description
The `watchEffect` runs immediately which caused the default value to get set into storage. Which means even if the value isn't actually set by the user, its already in storage which can pollute storage (which has a limited size). 

Using a `watch` will only update storage when the value is changed by the user. 